### PR TITLE
Fix fermi function in genbb_help

### DIFF
--- a/source/bxgenbb_help/src/decay0/fermi.cc
+++ b/source/bxgenbb_help/src/decay0/fermi.cc
@@ -117,9 +117,9 @@ namespace genbb {
       //double beta  = pe / we;
       double y = aZ * we / pe;
       double gamma1 = sqrt (1. - aZ * aZ);
-      gsl_sf_result res;
-      //int err = gsl_sf_lngamma_complex_e (gamma1, y, &res, &arg);
-      double lnr     = res.val;
+      gsl_sf_result res, arg;
+      gsl_sf_lngamma_complex_e (gamma1, y, &res, &arg);
+      double lnr = res.val;
       //double lnr_err = res.err;
       //double zarg     = arg.val;
       //double zarg_err = arg.err;

--- a/source/bxgenbb_help/src/decay0/fermi.cc
+++ b/source/bxgenbb_help/src/decay0/fermi.cc
@@ -81,14 +81,8 @@ namespace genbb {
       double g2 = gsl_sf_gamma (2. * gamma1 + 1.);
       gsl_sf_result res_lnr, res_arg;
       int status = gsl_sf_lngamma_complex_e (gamma1, y, &res_lnr, &res_arg);
-      if (status != GSL_SUCCESS)
-        {
-          std::ostringstream message;
-          message << "genbb::decay0::decay0_fermi_func: "
-                  << "GSL error at 'gsl_sf_lngamma_complex_e' invocation: "
-                  << gsl_strerror (status) << std::endl;
-          throw std::logic_error (message.str());
-        }
+      DT_THROW_IF(status != GSL_SUCCESS, std::logic_error, "GSL error at 'gsl_sf_lngamma_complex_e' invocation: "
+                  << gsl_strerror (status));
       double lnr = res_lnr.val;
       double g1 = std::exp (lnr);
       F0 *= (g1 * g1);
@@ -118,7 +112,9 @@ namespace genbb {
       double y = aZ * we / pe;
       double gamma1 = sqrt (1. - aZ * aZ);
       gsl_sf_result res, arg;
-      gsl_sf_lngamma_complex_e (gamma1, y, &res, &arg);
+      int status = gsl_sf_lngamma_complex_e (gamma1, y, &res, &arg);
+      DT_THROW_IF(status != GSL_SUCCESS, std::logic_error, "GSL error at 'gsl_sf_lngamma_complex_e' invocation: "
+                  << gsl_strerror (status));
       double lnr = res.val;
       //double lnr_err = res.err;
       //double zarg     = arg.val;

--- a/source/bxgenbb_help/src/decay0/fermi.cc
+++ b/source/bxgenbb_help/src/decay0/fermi.cc
@@ -9,6 +9,8 @@
 #include <gsl/gsl_sf.h>
 #include <CLHEP/Units/SystemOfUnits.h>
 
+#include <datatools/exception.h>
+
 #include <genbb_help/decay0/fermi.h>
 #include <genbb_help/decay0/particle.h>
 
@@ -47,11 +49,8 @@ namespace genbb {
       double g = std::sqrt (1. - alfaz * alfaz);
       gsl_sf_result res_lnr, res_arg;
       int status = gsl_sf_lngamma_complex_e (g, y, &res_lnr, &res_arg);
-      if (status != GSL_SUCCESS) {
-          std::cerr << "genbb_help::decay0_fermi_func_orig: GSL error: "
-               << gsl_strerror (status) << std::endl;
-          throw std::logic_error ("genbb_help::decay0_fermi_func_orig: GSL error at 'gsl_sf_lngamma_complex_e' invocation!");
-        }
+      DT_THROW_IF(status != GSL_SUCCESS, std::logic_error, "GSL error at 'gsl_sf_lngamma_complex_e' invocation: "
+                  << gsl_strerror (status));
       double lnr = res_lnr.val;
       double res = std::pow (p, 2. * g - 2.) * std::exp (M_PI * y + 2. * lnr);
       return res;


### PR DESCRIPTION
Due to some unused variable warnings raised during compilation, part of the code was badly commented. The following changes resurrect the historical code with ```gsl``` function to calculate gamma log distribution value