### PR TITLE
Add standard smart pointer interfaces for datatools::handle

### DIFF
--- a/source/bxdatatools/include/datatools/handle.h
+++ b/source/bxdatatools/include/datatools/handle.h
@@ -37,6 +37,7 @@
 // Third Party:
 // - Boost:
 #include <boost/shared_ptr.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/tracking.hpp>
 #include <boost/serialization/shared_ptr.hpp>
@@ -82,6 +83,7 @@ namespace datatools {
    *  };
    *  \endcode
    *
+   * \see make_handle()
    */
   template <typename T>
   class handle
@@ -242,6 +244,58 @@ namespace datatools {
     boost::shared_ptr<T> _sp_; //!< The embedded shared pointer.
 
   };
+
+  /*! \brief Constructs an object of type T and wraps it in a datatools::handle
+   *
+   * This function behaves in the same way as std::make_shared or
+   * std::make_unique. It is functionally equivalent to:
+   * \code
+   * handle<T>(new T(std::forward<Args>(args)...))
+   * \endcode
+   *
+   * \tparam T the type to construct and wrap in the handle
+   * \param args list of arguments with which the instance of T will be
+   * constructed
+   *
+   * \b Example:
+   * \code
+   * #include <datatools/handle.h>
+   * #include <iostream>
+   *
+   * struct Vec3
+   * {
+   *   int x, y, z;
+   *   Vec3() : x(0), y(0), z(0) { }
+   *   Vec3(int x, int y, int z) : x(x), y(y), z(z) { }
+   *   friend std::ostream& operator<<(std::ostream& os, Vec3& v) {
+   *     return os << '{' << "x:" << v.x << " y:" << v.y << " z:" << v.z  << '}';
+   *   }
+   * };
+   *
+   * int main()
+   * {
+   *   // Uses default constructor
+   *   auto v1 = datatools::make_handle<Vec3>();
+   *   // Uses constructor matching the arguments
+   *   auto v2 = datatools::make_handle<Vec3>(1, 2, 3);
+   *
+   *   std::cout << "v1: " << v1.grab() << '\n'
+   *             << "v2: " << v2.grab() << '\n';
+   * }
+   * \endcode
+   *
+   * Output:
+   * \code
+   * v1: {x:0 y:0 z:0}
+   * v2: {x:1 y:2 z:3}
+   * \endcode
+   */
+  template <typename T, typename... Args>
+  handle<T> make_handle(Args&& ... args)
+  {
+    // Use shared_ptr constructor for simplicity
+    return handle<T>(boost::make_shared<T>(std::forward<Args>(args)...));
+  }
 
   /*! \brief Templatized predicate class associated to handle instance.
    *

--- a/source/bxdatatools/testing/test_handle_operators.cxx
+++ b/source/bxdatatools/testing/test_handle_operators.cxx
@@ -1,0 +1,141 @@
+// Needed Stdlib/datatools items to perform by-hand testing
+#include <iostream>
+#include <exception>
+#include "datatools/exception.h"
+
+// Helpers for test cases
+#include <vector>
+#include <string>
+#include <algorithm>
+
+// Ourselves
+#include "datatools/handle.h"
+
+using datatools::handle;
+using datatools::make_handle;
+
+bool test_make_handle()
+{
+  // Creation of a simple type works
+  {
+    handle<int> x = make_handle<int>(42);
+    DT_THROW_IF( 42 != x.get(), std::logic_error,
+                 "make_handle int instance does not have required value 42" );
+    DT_THROW_IF( !x.unique(), std::logic_error,
+                 "make_handle created a non-unique int instance" );
+  }
+
+  // Creation of a standard type works
+  {
+    using MyType = std::vector<std::string>;
+    handle<MyType> x = make_handle<MyType>(3, "foo");
+
+    DT_THROW_IF( 3 != x.get().size(), std::logic_error,
+                 "make_handle did not create a 3 element vector" );
+    DT_THROW_IF( !x.unique(), std::logic_error,
+                 "make_handle created a non-unique std::vector<std::string> instance" );
+    DT_THROW_IF( "foo" != x.get().at(2), std::logic_error,
+                 "make_handle did not create vector with correct elements" );
+  }
+
+  return true;
+}
+
+bool test_handle_indirect_operator()
+{
+  // Test a handle on a trivial type...
+  {
+    handle<int> x = make_handle<int>(-13);
+
+    // ... Extract its value
+    int extracted = *x;
+    DT_THROW_IF( extracted != -13, std::logic_error,
+                 "extracted int value from handle != expected value -13");
+
+    // ... Set its value
+    (*x) = 42;
+    DT_THROW_IF( 42 != (*x), std::logic_error,
+                 "handle does not hold expected value 42");
+
+    // ... reset and confirm it throws
+    x.reset();
+    bool gotException{false};
+    try {
+      (*x) = 24;
+    }
+    catch (std::logic_error& e) {
+      //o.k., we've caught the expected error
+      gotException = true;
+    }
+    DT_THROW_IF( !gotException, std::logic_error,
+                 "handle operator*() did not throw exception on null data");
+  }
+
+  // Test a handle on a std type...
+  {
+    using MyType = std::vector<std::string>;
+    handle<MyType> x = make_handle<MyType>(3, "foo");
+
+    // Check its interfaces
+    // ... basic
+    DT_THROW_IF( 3 != (*x).size(), std::logic_error,
+                 "handle does not hold a vector of size 3");
+
+    // ... iterators
+    for(const auto& v : *x) {
+      DT_THROW_IF( "foo" != v, std::logic_error,
+                 "handle does not hold a vector with elements `foo`");
+    }
+  }
+
+  return true;
+}
+
+// Test usage of handleInstance->heldMemberFunction();
+bool test_handle_deref_operator()
+{
+  // Test a handle on a std type...
+  {
+    using MyType = std::vector<std::string>;
+    handle<MyType> x = make_handle<MyType>(3, "foo");
+
+    // Check its interfaces
+    // ... basic
+    DT_THROW_IF( 3 != x->size(), std::logic_error,
+                 "handle does not hold a vector of size 3");
+
+    // ... iterators
+    auto f = [](const MyType::value_type& v) {
+      DT_THROW_IF( "foo" != v, std::logic_error,
+                   "handle does not hold a vector with elements `foo`");};
+    std::for_each(x->begin(), x->end(), f);
+
+    // ... reset and confirm it throws
+    x.reset();
+    bool gotException{false};
+    try {
+      x->size();
+    }
+    catch (std::logic_error& e) {
+      //o.k., we've caught the expected error
+      gotException = true;
+    }
+    DT_THROW_IF( !gotException, std::logic_error,
+                 "handle operator->() did not throw exception on null data");
+  }
+
+  return true;
+}
+
+int main()
+{
+  DT_THROW_IF( !test_make_handle(), std::logic_error,
+               "test_make_handle failed" );
+  DT_THROW_IF( !test_handle_indirect_operator(), std::logic_error,
+               "test_handle_deref_operator failed" );
+  DT_THROW_IF( !test_handle_deref_operator(), std::logic_error,
+               "test_handle_deref_operator failed" );
+
+  return 0;
+}
+

--- a/source/bxdatatools_module.cmake
+++ b/source/bxdatatools_module.cmake
@@ -448,6 +448,7 @@ ${module_test_dir}/test_handle_1.cxx
 ${module_test_dir}/test_handle_2.cxx
 ${module_test_dir}/test_handle_3.cxx
 ${module_test_dir}/test_handle_macros.cxx
+${module_test_dir}/test_handle_operators.cxx
 ${module_test_dir}/test_integer_range.cxx
 ${module_test_dir}/test_ioutils.cxx
 ${module_test_dir}/test_kernel.cxx


### PR DESCRIPTION
In SuperNEMO, we've been losing a little bit of clarity in coding when using `datatools::handle` as whilst it is a smart pointer, it lacks some of the useful interfaces that the standard/boost/other ones usually have, e.g

- The `make_...` free functions so that construction is simplified and more robust, e.g.

  ```
  auto x = std::make_unique<int>(42);  
  ```

  vs in datatools:

  ```
  auto x = datatools::handle<int>{new int{42}};
  ```

  O.k., not much different, but see https://herbsutter.com/2013/05/29/gotw-89-solution-smart-pointers/ for some reasons to prefer the functional form

- The `*` and `->` dereference/indirect operators, so ease usage of the handle instance, e.g.

  ```
  auto x = std::make_unique<std::string>("hello world");
  std::cout << (*x) << std::endl; // prints "hello world"
  std::cout << x->size() << " or " << (*x).size() << std::endl; // prints "3 or 3"
  ```

  vs in datatools:

  ```
  auto x = datatools::handle<int>{new std::string{"hello world"}};
  std::cout << x.get() << std::endl;
  std::cout << x.get().size() << std::endl;
  ```

  The operators also assist in smoothing use in the STL and so on.

This PR adds a new `make_handle` free function to implement construction of a handle instance in the same fashion as the standard/boost smart pointers (it uses the boost one under the hood), plus implementations of the `*` and `->` operators, together with unit tests and documentation. These allow the use of handles in an identical way to other smart pointers, e.g.

```
auto x = datatools::make_handle<std::string>("hello world");
std::cout << (*x) << std::endl; // prints "hello world"
std::cout << x->size() << " or " << (*x).size() << std::endl; // prints "3 or 3"
```

The operators have identical behaviour to `get` and `grab`, so the correct const/non-const versions are picked, depending on the const context on both the handle and the held instance.