### PR TITLE
Restore Bayeux_INCLUDE_DIR{S} in cmake config

### DIFF
--- a/cmake/BayeuxConfig.cmake.in
+++ b/cmake/BayeuxConfig.cmake.in
@@ -54,10 +54,11 @@ set(Bayeux_docs_FOUND "@BAYEUX_WITH_DOCS@")
 # End of Cmake Generated
 
 #-----------------------------------------------------------------------
-# set_and_check(Bayeux_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_CMAKEDIR_TO_INCLUDEDIR@")
-# set(Bayeux_INCLUDE_DIRS "${Bayeux_INCLUDE_DIR}" "${Bayeux_INCLUDE_DIR}/bayeux" )
-# message( STATUS "Bayeux_INCLUDE_DIR  = ${Bayeux_INCLUDE_DIR}")
-# message( STATUS "Bayeux_INCLUDE_DIRS = ${Bayeux_INCLUDE_DIRS}")
+# Though usage requirements help clients link, variables for the
+# header path(s) may still be needed by tools needed downstream, such
+# as ROOT dictionary generation
+set_and_check(Bayeux_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_CMAKEDIR_TO_INCLUDEDIR@")
+set(Bayeux_INCLUDE_DIRS "${Bayeux_INCLUDE_DIR}" "${Bayeux_INCLUDE_DIR}/bayeux" )
 
 #-----------------------------------------------------------------------
 # - Refind third party deps here to regenerate imported targets


### PR DESCRIPTION
Clients of Bayeux will primarily link to the Bayeux::Bayeux imported target to pick up header paths through usage requirements. However, some use cases may also require only the header paths, or be unable to extract them for use by tools such as ROOT.

Restore setting of header path CMake variables to allow clients to use these if required.

This is needed in SuperNEMO to enable creation of ROOT dictionaries of types that use types from Bayeux.