### PR TITLE
Preliminary fixes to support Boost 1.68

### DIFF
--- a/source/bxbayeux/testing/test_bayeux.cxx
+++ b/source/bxbayeux/testing/test_bayeux.cxx
@@ -12,7 +12,7 @@
 #include <bayeux/datatools/urn_query_service.h>
 #include <bayeux/datatools/utils.h>
 
-int main( int /*argc_*/, char** /*argv_*/ )
+int main( int argc_, char** argv_ )
 {
   std::clog << "[info] You may activate debug logging from your shell with: \n\n"
             << "\texport BAYEUX_SYS_LOGGING=\"trace\" \n"
@@ -23,7 +23,7 @@ int main( int /*argc_*/, char** /*argv_*/ )
             << "\texport DATATOOLS_SYS_LOGGING=\"fatal\" \n"
             << std::endl;
   int result = EXIT_SUCCESS;
-  ::bayeux::initialize(0, nullptr, 0);
+  ::bayeux::initialize(argc_, argv_, 0);
 
   try {
 

--- a/source/bxdatatools/include/datatools/service_tools-inl.h
+++ b/source/bxdatatools/include/datatools/service_tools-inl.h
@@ -45,7 +45,7 @@ namespace datatools {
     if (!service_exists(services_, service_name_)) {
       return false;
     }
-    base_service & srvc = get_service(services_, service_name_);
+    const base_service & srvc = get_service(services_, service_name_);
     const std::type_info & ti = typeid(T);
     const std::type_info & tf = typeid(srvc);
     return ti == tf;

--- a/source/bxdatatools/src/io_factory.cc
+++ b/source/bxdatatools/src/io_factory.cc
@@ -250,6 +250,10 @@ namespace datatools {
     }
 
     if (_ixar_ptr_ != nullptr) {
+      // To the end?
+      if(_in_) _in_->seekg(0, std::ios_base::end);
+      if(_fin_) _fin_->seekg(0, std::ios_base::end);
+      if(_in_fs_) _in_fs_->seekg(0, std::ios_base::end);
       delete _ixar_ptr_;
       _ixar_ptr_ = nullptr;
     }

--- a/source/bxdatatools/testing/test_configuration_variant_service.cxx
+++ b/source/bxdatatools/testing/test_configuration_variant_service.cxx
@@ -28,7 +28,7 @@ struct processing
 
 int main(int argc_, char ** argv_)
 {
-  bayeux::initialize();
+  bayeux::initialize(argc_, argv_);
   int error_code = EXIT_SUCCESS;
   app_config params;
 

--- a/source/bxdatatools/testing/test_configuration_variant_service_2.cxx
+++ b/source/bxdatatools/testing/test_configuration_variant_service_2.cxx
@@ -30,7 +30,7 @@ struct processing
 
 int main(int argc_, char ** argv_)
 {
-  bayeux::initialize();
+  bayeux::initialize(argc_, argv_);
   int error_code = EXIT_SUCCESS;
   app_config params;
 

--- a/source/bxdatatools/testing/test_urn_db_service.cxx
+++ b/source/bxdatatools/testing/test_urn_db_service.cxx
@@ -10,10 +10,10 @@
 void test_urn_db_service_0();
 void test_urn_db_service_1();
 
-int main (int /* argc_ */, char ** /*argv_*/)
+int main (int argc_, char ** argv_)
 {
   int error_code = EXIT_SUCCESS;
-  datatools::initialize();
+  datatools::initialize(argc_, argv_);
   try {
     std::clog << "Test of the 'datatools::urn_db_service' class..." << std::endl;
 

--- a/source/bxdatatools/testing/test_urn_db_service_2.cxx
+++ b/source/bxdatatools/testing/test_urn_db_service_2.cxx
@@ -9,10 +9,10 @@
 
 void test_urn_db_service_0();
 
-int main (int /* argc_ */, char ** /*argv_*/)
+int main (int argc_, char ** argv_)
 {
   int error_code = EXIT_SUCCESS;
-  datatools::initialize();
+  datatools::initialize(argc_, argv_);
   try {
     std::clog << "Test of the 'datatools::urn_db_service' class..." << std::endl;
 

--- a/source/bxdatatools/testing/test_urn_query_service.cxx
+++ b/source/bxdatatools/testing/test_urn_query_service.cxx
@@ -19,9 +19,9 @@
 
 void test_urn_query_service_0();
 
-int main (int /* argc_ */, char ** /*argv_*/)
+int main (int argc_, char ** argv_)
 {
-  bayeux::initialize(0,nullptr,0);
+  bayeux::initialize(argc_,argv_,0);
   int error_code = EXIT_SUCCESS;
   try {
     std::clog << "Test of the 'datatools::urn_query_service' class..." << std::endl;

--- a/source/bxdatatools/testing/test_urn_to_path_resolver_service.cxx
+++ b/source/bxdatatools/testing/test_urn_to_path_resolver_service.cxx
@@ -14,10 +14,10 @@
 
 void trps0();
 
-int main(int /* argc_ */, char ** /* argv_ */)
+int main(int argc_, char ** argv_)
 {
   int error_code = EXIT_SUCCESS;
-  datatools::initialize();
+  datatools::initialize(argc_, argv_);
   try {
     std::clog << "Test program for the 'datatools::urn_to_path_resolver_service' class."
               << std::endl;

--- a/source/bxdatatools/testing/test_utils.cxx
+++ b/source/bxdatatools/testing/test_utils.cxx
@@ -89,7 +89,7 @@ void test_bit_manipulation()
   return;
 }
 
-void test_path_manipulation()
+void test_path_manipulation(int argc, char* argv[])
 {
   {
     std::clog << "Testing wordexp : " << std::endl;
@@ -346,7 +346,7 @@ void test_path_manipulation()
   }
   datatools::kernel & krnl = datatools::kernel::instance();
   if (! krnl.is_initialized()) {
-    krnl.initialize(0, 0);
+    krnl.initialize(argc, argv);
   }
   if (krnl.has_library_info_register()) {
     datatools::library_info & lib_info_reg
@@ -430,13 +430,13 @@ void test_path_manipulation()
 }
 
 
-int main(int /*argc*/, const char** /*argv*/)
+int main(int argc, char** argv)
 {
   try {
 
     test_bit_manipulation();
 
-    test_path_manipulation();
+    test_path_manipulation(argc, argv);
 
     test_quotes_manipulation();
 

--- a/source/bxmctools/testing/test_g4_manager.cxx
+++ b/source/bxmctools/testing/test_g4_manager.cxx
@@ -62,7 +62,7 @@ void test_1(const params & pars_);
 
 int main (int argc_, char ** argv_)
 {
-  bayeux::initialize();
+  bayeux::initialize(argc_, argv_);
   // Register signal and signal handler
   // signal(SIGABRT, signal_callback_handler);
 


### PR DESCRIPTION
To address Issues #20, #29, and #36, this provides preliminary support for Boost 1.68 in Bayeux. The main fixes are:

1. Always call `bayeux::initialise` and/or `datatools::kernel` initialisation with non-null `argc/argv` as otherwise the underlying `boost::program_options` with throw an exception (it seems to require non-null args now). This only affects tests as yet, no change was made to the initialisation functions yet, but that may be preffered.

2. Always move input streams to the end in `io_factory` before destructing the xml archive, if that's used. This is only a preliminary fix that gets most tests passing, and is only based on information gleaned from:

- boostorg/serialization#82
- boostorg/serialization#99
- boostorg/serialization#109

With these two commits, Bayeux will compile and pass tests using Boost 1.68, except for:

```
The following tests FAILED:
        216 - geomtools-test_regular_3d_mesh_placement (Failed)
        330 - mctools-validation_serialization (Failed)
Errors while running CTest
```

The detailed output of these is:

```
snemo-shell> ctest -VV -I 216,216
UpdateCTestConfiguration  from :/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/build/DartConfiguration.tcl
Test project /Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 216
    Start 216: geomtools-test_regular_3d_mesh_placement

216: Test command: /Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/build/BuildProducts/bin/bxtests/geomtools-test_regular_3d_mesh_placement
216: Environment variables: 
216:  GEOMTOOLS_RESOURCE_DIR=/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/source/bxgeomtools/resources
216:  GEOMTOOLS_TESTING_DIR=/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/source/bxgeomtools/testing
216: Test timeout computed to be: 10000000
216: Daughter2 placement:
216: |-- Number of items  = 15
216: |   |-- Basic placement :
216: |   |-- Number of items  = 1
216: |   |-- Valid : 1
216: |   |-- Translation : (-150,0,0)
216: |   |-- Euler Angles (ZYZ): Yes
216: |   |   |-- Phi :   0 degree
216: |   |   |-- Theta : 0 degree
216: |   |   `-- Delta : 0 degree
216: |   |-- Rotation :
216: |   |   `-- [ (           1             0             0)
216: |   |         (           0             1             0)
216: |   |         (           0             0             1) ]
216: |   `-- Inverse rotation :
216: |       `-- [ (           1             0             0)
216: |             (           0             1             0)
216: |             (           0             0             1) ]
216: |-- Mode : 1
216: |-- Column step : 250
216: |-- Row step : 250
216: |-- Number of columns : 5
216: |-- Number of rows : 3
216: `-- Centered :1
216: Daughter1 placement:
216: |-- Number of items  = 1
216: |-- Valid : 1
216: |-- Translation : (-550,0,0)
216: |-- Euler Angles (ZYZ): Yes
216: |   |-- Phi :   0 degree
216: |   |-- Theta : 90 degree
216: |   `-- Delta : 0 degree
216: |-- Rotation :
216: |   `-- [ (           0             0            -1)
216: |         (           0             1             0)
216: |         (           1             0             0) ]
216: `-- Inverse rotation :
216:     `-- [ (           0             0             1)
216:           (           0             1             0)
216:           (          -1             0             0) ]
216: [notice:void geomtools::regular_3d_mesh_placement::_load_cache(const std::string &):878] Loading 3D-mesh nodes cache file '/Users/bmorgan/.cache/Bayeux/geomtools/test_regular_3d_mesh_placement-nodes.xml'...
216: error: [void geomtools::regular_3d_mesh_placement::_load_cache(const std::string &):916: Cannot find node record in the cache file '/Users/bmorgan/.cache/Bayeux/geomtools/test_regular_3d_mesh_placement-nodes.xml'!]
1/1 Test #216: geomtools-test_regular_3d_mesh_placement ...***Failed    0.08 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.11 sec

The following tests FAILED:
        216 - geomtools-test_regular_3d_mesh_placement (Failed)
Errors while running CTest
```

and:

```
snemo-shell> ctest -VV -I 330,330
UpdateCTestConfiguration  from :/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/build/DartConfiguration.tcl
Test project /Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 330
    Start 330: mctools-validation_serialization

330: Test command: /Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/source/bxmctools/validation/serialization/run.sh "--work-dir" "/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/build/source/bxmctools/validation/serialization" "--source-dir" "/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/source/bxmctools/validation/serialization"
330: Environment variables: 
330:  PATH=/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/opt/python/libexec/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/opt/libxml2/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/opt/icu4c/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/opt/readline/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/opt/qt5-base/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/opt/sqlite/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/opt/zlib/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/opt/gettext/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/opt/sphinx-doc/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/opt/openssl/bin:/opt/X11/bin:/Library/TeX/texbin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/bin:/Users/bmorgan/Sandboxes/com.github/supernemo-dbd/brew/Library/Homebrew/shims/scm:/usr/bin:/bin:/usr/sbin:/sbin:/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/build/BuildProducts/bin
330: Test timeout computed to be: 10000000
330: [info] Running run.sh...
330: [info] Source dir       = '/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/source/bxmctools/validation/serialization'
330: [info] Working dir      = '/Users/bmorgan/Sandboxes/com.github/drbenmorgan/Bayeux.git/build/source/bxmctools/validation/serialization'
330: [info] Serial downgrade = 0
330: 
330: Load the sample MC hit data file (version 1)...
330: [info] Base step hit class library version  = 2
330: [info] Simulated data class library version = 3
330: [fatal:int main(int, char **):102] [void datatools::data_reader::load(const std::string &, Data &) [Data = mctools::base_step_hit]:605: No more record tag!]
330: [error] exload failed !
1/1 Test #330: mctools-validation_serialization ...***Failed    0.10 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.13 sec

The following tests FAILED:
        330 - mctools-validation_serialization (Failed)
Errors while running CTest
```

These don't appear related to the XML issue, but 330 is possibly due to the Boost version change? As per #36, requires validation that data written with old versions of Boost can be read with new.

