### PR TITLE
feature xrootd compatibility at CC/IN2P3

### DIFF
--- a/source/bxbrio/src/reader.cc
+++ b/source/bxbrio/src/reader.cc
@@ -8,6 +8,7 @@
 
 // Third Party:
 // - Boost:
+#include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 // - ROOT:
 #ifdef __clang__
@@ -170,7 +171,7 @@ namespace brio {
   {
     _filename = filename_;
     datatools::fetch_path_with_env(_filename);
-    DT_THROW_IF(!boost::filesystem::exists(_filename),
+    DT_THROW_IF(!boost::starts_with(_filename,"root://") && !boost::filesystem::exists(_filename),
                 std::runtime_error,
                 "File '" << _filename << "' does not exist !");
 

--- a/source/bxdpp/src/simple_brio_data_source.cc
+++ b/source/bxdpp/src/simple_brio_data_source.cc
@@ -82,9 +82,9 @@ namespace dpp {
         file_mode = true;
         file_name = label;
         boost::replace_first (file_name, "file://", "");
-			} else if (boost::starts_with (label, "root://")) {
-				file_mode = true;
-				file_name = label;
+      } else if (boost::starts_with (label, "root://")) {
+        file_mode = true;
+        file_name = label;
       } else if (boost::starts_with (label, "http://")) {
         download_mode = true;
 #if BOOST_FILESYSTEM_VERSION == 3

--- a/source/bxdpp/src/simple_brio_data_source.cc
+++ b/source/bxdpp/src/simple_brio_data_source.cc
@@ -82,6 +82,9 @@ namespace dpp {
         file_mode = true;
         file_name = label;
         boost::replace_first (file_name, "file://", "");
+			} else if (boost::starts_with (label, "root://")) {
+				file_mode = true;
+				file_name = label;
       } else if (boost::starts_with (label, "http://")) {
         download_mode = true;
 #if BOOST_FILESYSTEM_VERSION == 3
@@ -135,7 +138,7 @@ namespace dpp {
 
   void simple_brio_data_source::_open_file_source ()
   {
-    DT_THROW_IF (! boost::filesystem::exists (_source_record.effective_label),
+    DT_THROW_IF (!boost::starts_with(_source_record.effective_label,"root://") && !boost::filesystem::exists (_source_record.effective_label),
                  std::runtime_error,
                  "File '" << _source_record.effective_label << "' does not exist !");
 

--- a/source/bxdpp/src/simple_data_source.cc
+++ b/source/bxdpp/src/simple_data_source.cc
@@ -75,6 +75,9 @@ namespace dpp {
             file_mode = true;
             file_name = label;
             boost::replace_first(file_name, "file://", "");
+          } else if (boost::starts_with (label, "root://")) {
+            file_mode = true;
+            file_name = label;
           } else if (boost::starts_with (label, "http://")) {
             download_mode = true;
 #if BOOST_FILESYSTEM_VERSION == 3
@@ -139,7 +142,7 @@ namespace dpp {
   {
     namespace ds = datatools;
     //cerr << "DEVEL: dpp::simple_data_source::_open_file_source: Entering..." << std::endl;
-    DT_THROW_IF (! boost::filesystem::exists(_source_record.effective_label),
+    DT_THROW_IF (!boost::starts_with(_source_record.effective_label,"root://") && !boost::filesystem::exists(_source_record.effective_label),
                  std::logic_error,
                  "File '" << _source_record.effective_label << "' does not exist !");
 


### PR DESCRIPTION
- enable bxbrio reader to handle file starting with "root://"
- disable check on file existence (boost::filesystem::exists) as xrootd file can not be probe as usual file
