### PR TITLE
Resolve C++17 and Dependency Issues in Testing

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -399,6 +399,18 @@ if(BAYEUX_ENABLE_TESTING)
       set_property(TEST ${_testname}
         APPEND PROPERTY ENVIRONMENT ${${_m}_TEST_ENVIRONMENT}
         )
+
+      ### Require that brio-reader tests run after writer ones...
+      if(_testname MATCHES ".*brio_reader.*")
+        string(REPLACE "reader" "writer" _writer_dep ${_testname})
+        set_property(TEST ${_testname} PROPERTY DEPENDS ${_writer_dep})
+      endif()
+
+      if(_testname MATCHES "brio-test_reader*")
+        set_property(TEST ${_testname} PROPERTY DEPENDS "brio-test_writer;brio-test_writer_1;brio-test_writer_2")
+
+      endif()
+
     endforeach()
   endforeach()
 endif()

--- a/source/bxdatatools/testing/test_serialization_4.cxx
+++ b/source/bxdatatools/testing/test_serialization_4.cxx
@@ -18,14 +18,12 @@
 #include <datatools/safe_serial.h>
 
 
-using namespace std;
-
 // A serializable class:
 class data : public datatools::i_serializable
 {
 public:
-  static const string SERIAL_TAG;
-  virtual const string & get_serial_tag () const;
+  static const std::string SERIAL_TAG;
+  virtual const std::string & get_serial_tag () const;
 
 public:
   int32_t value; // An integral value (32 bits)
@@ -45,9 +43,9 @@ void data::serialize (Archive & ar_,
   return;
 }
 
-const string data::SERIAL_TAG = "data";
+const std::string data::SERIAL_TAG = "data";
 
-const string & data::get_serial_tag () const
+const std::string & data::get_serial_tag () const
 {
   return data::SERIAL_TAG;
 }
@@ -58,7 +56,7 @@ const string & data::get_serial_tag () const
 
 int main (void)
 {
-  string filename = "test_serialization_4.xml";
+  std::string filename = "test_serialization_4.xml";
 
   {
     // Save 1000 data objects:
@@ -93,9 +91,9 @@ int main (void)
           }
         else
           {
-            string bad_tag = reader.get_record_tag ();
-            clog << "ERROR: Unknown serialization tag '"
-                 << bad_tag << "'! Cannot de-serialized more !" << endl;
+            std::string bad_tag = reader.get_record_tag ();
+            std::clog << "ERROR: Unknown serialization tag '"
+                 << bad_tag << "'! Cannot de-serialized more !" << std::endl;
             break;
           }
       }


### PR DESCRIPTION
This PR provides two fixes for testing of Bayeux:

1. Remove name clash in a data tools serialisation test caused by use of "using namespace std" and the presence of a `std::data` class in C++17
2. Add execution-order dependencies on brio write/read tests to allow use of "ctest -jN" for speeding up testing