### PR TITLE
Provide safe copy/move for properties and multi_properties

### DIFF
--- a/source/bxdatatools/include/datatools/multi_properties.h
+++ b/source/bxdatatools/include/datatools/multi_properties.h
@@ -124,7 +124,19 @@ namespace datatools {
             const std::string & meta_ = "");
 
       /// Destructor
-      virtual ~entry();
+      virtual ~entry() = default;
+
+      /// Copy constructor
+      entry(const entry&) = default;
+
+      /// Copy assignment
+      entry& operator=(const entry&) = default;
+
+      /// Move constructor
+      entry(entry&&) = default;
+
+      /// Move assignment
+      entry& operator=(entry&&) = default;
 
       /// Return a const reference to the collection of properties
       const properties& get_properties() const;
@@ -204,13 +216,19 @@ namespace datatools {
                      bool debug_ = false);
 
     /// Destructor
-    virtual ~multi_properties();
+    virtual ~multi_properties() = default;
 
     /// Copy constructor
     multi_properties(const multi_properties &);
 
     /// Assignment operator
     multi_properties & operator=(const multi_properties &);
+
+    // Move constructor
+    multi_properties(multi_properties&&) = default;
+
+    // Move assignment
+    multi_properties& operator=(multi_properties&&) = default;
 
     /// Check the debug flag
     bool is_debug() const;

--- a/source/bxdatatools/testing/test_properties.cxx
+++ b/source/bxdatatools/testing/test_properties.cxx
@@ -17,6 +17,7 @@
 #include <datatools/clhep_units.h>
 
 void test_more();
+void test_key_validation();
 
 int main(int argc_, char ** argv_)
 {
@@ -91,9 +92,6 @@ int main(int argc_, char ** argv_)
     clog << "========================================" << endl;
 
     datatools::properties my_dict("A list of user properties; group=Foo; date=01-02-2016");
-    if (! use_validator) {
-      my_dict.unset_key_validator();
-    }
     my_dict.dump(clog);
     clog << endl;
     clog << "========================================" << endl;
@@ -324,6 +322,8 @@ int main(int argc_, char ** argv_)
     test_more();
     std::clog << "\n";
 
+    test_key_validation();
+
   } catch (std::exception & x) {
     std::clog << "error: " << x.what () << std::endl;
     error_code = EXIT_FAILURE;
@@ -359,4 +359,72 @@ void test_more()
   }
 
   return;
+}
+
+void test_key_validation()
+{
+  datatools::properties a;
+  bool noExceptionThrown = true;
+
+  // Empty key is failure
+  try {
+    a.store("", "foo");
+  }
+  catch (std::exception&) {
+    noExceptionThrown = false;
+  }
+  if(noExceptionThrown) {
+    DT_THROW(std::logic_error, "Storing an empty key did not throw");
+  }
+
+  // Key ending in '.' is failure
+  noExceptionThrown = true;
+  try {
+    a.store("foo.", "bar");
+  }
+  catch (std::exception&) {
+    noExceptionThrown = false;
+  }
+  if(noExceptionThrown) {
+    DT_THROW(std::logic_error, "Storing a key ending in '.' did not throw");
+  }
+
+  // Key beginning with '.' is failure
+  noExceptionThrown = true;
+  try {
+    a.store(".foo", "bar");
+  }
+  catch (std::exception&) {
+    noExceptionThrown = false;
+  }
+  if(noExceptionThrown) {
+    DT_THROW(std::logic_error, "Storing a key beginning with '.' did not throw");
+  }
+
+  // Key beginning with digit is failure
+  std::string digits{"0123456789"};
+  for (char c : digits) {
+    noExceptionThrown = true;
+    try {
+      a.store(c+"foo", "bar");
+    }
+    catch (std::exception&) {
+      noExceptionThrown = false;
+    }
+    if(noExceptionThrown) {
+      DT_THROW(std::logic_error, "Storing a key beginning with '" << c << "' did not throw");
+    }
+  }
+
+  // Key containing non-allowed character is failure
+  noExceptionThrown = true;
+  try {
+    a.store("spaces and * are invalid", "bar");
+  }
+  catch (std::exception&) {
+    noExceptionThrown = false;
+  }
+  if(noExceptionThrown) {
+    DT_THROW(std::logic_error, "Storing a key containing invalis chars did not throw");
+  }
 }

--- a/source/bxdatatools/testing/test_properties_2.cxx
+++ b/source/bxdatatools/testing/test_properties_2.cxx
@@ -36,10 +36,6 @@ int main (int argc_, char ** argv_)
       srand48 (seed);
 
       datatools::properties my_dict ("a list of user properties");
-      if (! use_validator)
-        {
-          my_dict.unset_key_validator ();
-        }
       my_dict.dump (clog);
       my_dict.store ("name","my name");
       my_dict.store ("firstname","my firstname");

--- a/source/bxdatatools/testing/test_properties_2b.cxx
+++ b/source/bxdatatools/testing/test_properties_2b.cxx
@@ -35,10 +35,6 @@ int main (int argc_, char ** argv_)
       srand48 (seed);
 
       datatools::properties my_dict ("a list of user properties");
-      if (! use_validator)
-        {
-          my_dict.unset_key_validator ();
-        }
       my_dict.dump (clog);
       my_dict.store ("name","my name");
       my_dict.store ("firstname","my firstname");


### PR DESCRIPTION
## Problem outline
Due to the extensive use of `properties`/`multi_properties` in Bayeux, and thus by clients, efficient copy and move are vital for performance. Whilst compiler-generated copy constructors are available for `properties` these are not safe, and in addition move construction is likely to be unavailable due to the presence of a user defined destructor.

The lack of safety comes from the holding of a possibly owned pointer-to-base of `base_key_validator` in properties. There is no safe way to copy this because it cannot be deep-copied. Move is safe but awkward. In addition, allowing users to set the key validator is conceptually problematic in two ways:

1. The validator is never serialised, so de-serialisation/use may lead to incorrect or undefined behaviour.
2. Key validation is tied to parsing of input `properties` text files, so a custom validator may cause parse errors or incorrect behaviour.

## Solution in this Pull Request
1. Remove ability to set a custom key validator in `properties`
2. Refactor default key validation into the `_validate_key_` member function, simplifying logic and removing additional data member
3. Provide defaulted copy and move constructors and assignment operators for `properties` and `multi_properties` following ISO CPP Guidelines
4. Apply `modernize-` and `performance-` fixes from `clang-tidy`

These features will be required by SuperNEMO, and there will be an additional Pull Request focussing on the same issue for core `datatools`, `geomtools` and `mctools` classes. As these all use `properties` this initial Pull Request should be merged first.

CC: @emchauve, @yramachers, @cherylepatrick
