### PR TITLE
Provide default copy/move operations for core Bayeux data classes

### DIFF
--- a/source/bxdatatools/include/datatools/event_id.h
+++ b/source/bxdatatools/include/datatools/event_id.h
@@ -98,10 +98,10 @@ namespace datatools {
     event_id& operator=(const event_id&) = default;
 
     //! Move constructor
-    event_id(event_id&& other) = default;
+    event_id(event_id&&) = default;
 
     //! Move assignment
-    event_id& operator=(event_id&& rhs) = default;    
+    event_id& operator=(event_id&&) = default;    
 
     //! Invalidate the id.
     virtual void clear();

--- a/source/bxdatatools/include/datatools/event_id.h
+++ b/source/bxdatatools/include/datatools/event_id.h
@@ -77,7 +77,7 @@ namespace datatools {
     //! The default constructor.
     /** Initialized to an invalid id.
      */
-    event_id();
+    event_id() = default;
 
     //! A constructor that sets only the event number.
     explicit event_id(int e_);
@@ -89,7 +89,19 @@ namespace datatools {
     event_id(int r_, int e_);
 
     //! The destructor.
-    virtual ~event_id();
+    virtual ~event_id() = default;
+
+    //! Copy constructor
+    event_id(const event_id&) = default;
+
+    //! Copy assignment
+    event_id& operator=(const event_id&) = default;
+
+    //! Move constructor
+    event_id(event_id&& other) = default;
+
+    //! Move assignment
+    event_id& operator=(event_id&& rhs) = default;    
 
     //! Invalidate the id.
     virtual void clear();
@@ -187,8 +199,8 @@ namespace datatools {
 
   private:
 
-    int32_t _run_number_;   //!< The number of the run.
-    int32_t _event_number_; //!< The number of the event within the run.
+    int32_t _run_number_ = INVALID_RUN_NUMBER;   //!< The number of the run.
+    int32_t _event_number_ = INVALID_EVENT_NUMBER; //!< The number of the event within the run.
 
     //! Support for Boost-based serialization
     DATATOOLS_SERIALIZATION_DECLARATION_ADVANCED(event_id)

--- a/source/bxdatatools/include/datatools/handle.h
+++ b/source/bxdatatools/include/datatools/handle.h
@@ -178,10 +178,24 @@ namespace datatools {
     }
 
     //! Destructor
-    virtual ~handle()
+    virtual ~handle() = default;
+
+    //! Copy constructor
+    handle(const handle&) = default;
+
+    //! Copy assignment
+    handle& operator=(const handle& rhs) = default;
+
+    //! Move constructor
+    handle(handle&&) = default;
+
+    //! Move assignment
+    handle& operator=(handle&& rhs) = default;
+
+    //! Return number of handle objects referring to the referenced object
+    size_t use_count() const 
     {
-      _sp_.reset();
-      return;
+      return _sp_.use_count();
     }
 
     //! Check if the current handle holds an uniquely referenced object

--- a/source/bxdatatools/include/datatools/handle.h
+++ b/source/bxdatatools/include/datatools/handle.h
@@ -190,7 +190,7 @@ namespace datatools {
     handle(handle&&) = default;
 
     //! Move assignment
-    handle& operator=(handle&& rhs) = default;
+    handle& operator=(handle&&) = default;
 
     //! Return number of handle objects referring to the referenced object
     size_t use_count() const 

--- a/source/bxdatatools/src/event_id.cc
+++ b/source/bxdatatools/src/event_id.cc
@@ -27,16 +27,8 @@ namespace datatools {
   const char event_id::IO_FORMAT_ANY;
   const char event_id::IO_FORMAT_INVALID;
 
-  event_id::event_id()
-    : _run_number_(INVALID_RUN_NUMBER)
-    , _event_number_(INVALID_EVENT_NUMBER)
-  {
-    return;
-  }
-
   event_id::event_id(int event_number_)
-    : _run_number_(INVALID_RUN_NUMBER)
-    ,  _event_number_(INVALID_EVENT_NUMBER)
+    : event_id()
   {
     this->set_event_number(event_number_);
     return;
@@ -45,11 +37,6 @@ namespace datatools {
   event_id::event_id(int run_number_, int event_number_)
   {
     this->set(run_number_, event_number_);
-    return;
-  }
-
-  event_id::~event_id()
-  {
     return;
   }
 

--- a/source/bxdatatools/testing/test_event_id.cxx
+++ b/source/bxdatatools/testing/test_event_id.cxx
@@ -21,6 +21,7 @@
 // This project:
 #include <datatools/io_factory.h>
 
+void test_0();
 void test_1();
 
 // TEST_CASE("Test Bayeux/datatools::event_id class", "[bxdatatools][event_id]")
@@ -33,6 +34,7 @@ int main(int /* argc_ */, char ** /* argv_ */)
   int error_code = EXIT_SUCCESS;
   try {
     std::clog << "Hello, this is a test program for class 'datatools::event_id'!" << std::endl;
+    test_0();
     test_1();
   } catch(std::exception & x) {
     std::cerr << "error: " << x.what() << std::endl;
@@ -44,14 +46,35 @@ int main(int /* argc_ */, char ** /* argv_ */)
   return error_code;
 }
 
+void test_0()
+{
+  datatools::event_id a;
+
+  DT_THROW_IF(a.is_valid(), std::logic_error, "Default constructed event_id must be invalid");
+
+  datatools::event_id b{1,2};
+  DT_THROW_IF(!b.is_valid(), std::logic_error, "User constructed event_id must be valid");
+
+  datatools::event_id c{b};
+  DT_THROW_IF(!(c == b), std::logic_error, "Copy construction must yield identical objects");
+
+  datatools::event_id d = b;
+  DT_THROW_IF(!(c == b), std::logic_error, "Copy assignment must yield identical objects");
+
+  datatools::event_id e{std::move(d)};
+  DT_THROW_IF(!(e == b), std::logic_error, "Move construction does not yield correct object");
+
+  datatools::event_id f = std::move(e);
+  DT_THROW_IF(!(f == b), std::logic_error, "Move assignment does not yield correct object");
+}
+
 void test_1()
 {
-  using namespace std;
   datatools::event_id my_id;
 
   my_id.set(666, 34);
 
-  clog << "Event id = " << my_id << endl;
+  std::clog << "Event id = " << my_id << std::endl;
 
   std::vector<std::string> tokens = {
     "666_7635",
@@ -63,41 +86,41 @@ void test_1()
   for (auto tok : tokens) {
     try {
       std::istringstream ins(tok);
-      clog << "Enter event id [format=XXX_YYY] ? ";
+      std::clog << "Enter event id [format=XXX_YYY] ? ";
       ins >> my_id;
       if(! ins) {
-        throw runtime_error("Format error!");
+        throw std::runtime_error("Format error!");
       }
-      clog << "Token : '" << tok << "'" << std::endl;
-      clog << "Event id = " << my_id << endl;
-      my_id.tree_dump(clog, "datatools::event_id:");
-    } catch(exception & x) {
-      cerr << "Format error !" << endl;
+      std::clog << "Token : '" << tok << "'" << std::endl;
+      std::clog << "Event id = " << my_id << std::endl;
+      my_id.tree_dump(std::clog, "datatools::event_id:");
+    } catch(std::exception & x) {
+      std::cerr << "Format error !" << std::endl;
     }
   }
 
-  string filename = "test_event_id.xml";
+  std::string filename = "test_event_id.xml";
   {
-    clog << "Storing..." << endl;
-    list<datatools::event_id> ids;
+    std::clog << "Storing..." << std::endl;
+    std::list<datatools::event_id> ids;
     datatools::data_writer writer(filename);
     for(int i = 0; i < 4; i++) {
       ids.push_back(datatools::event_id(666, i));
-      ids.back().tree_dump(clog, "event_id","<<< ");
+      ids.back().tree_dump(std::clog, "event_id","<<< ");
       writer.store(ids.back());
     }
   }
 
   {
-    clog << "Loading..." << endl;
-    list<datatools::event_id> ids;
+    std::clog << "Loading..." << std::endl;
+    std::list<datatools::event_id> ids;
     datatools::data_reader reader(filename);
     while(reader.has_record_tag()) {
       if(reader.record_tag_is(datatools::event_id::SERIAL_TAG)) {
         datatools::event_id id;
         ids.push_back(id);
         reader.load(ids.back());
-        ids.back().tree_dump(clog, "event_id",">>> ");
+        ids.back().tree_dump(std::clog, "std::event_id",">>> ");
       } else {
         break;
       }

--- a/source/bxdatatools/testing/test_handle_construction.cxx
+++ b/source/bxdatatools/testing/test_handle_construction.cxx
@@ -1,0 +1,65 @@
+// Needed Stdlib/datatools items to perform by-hand testing
+#include <iostream>
+#include <exception>
+#include "datatools/exception.h"
+
+// Helpers for test cases
+#include <vector>
+#include <string>
+#include <algorithm>
+
+// Ourselves
+#include "datatools/handle.h"
+
+using datatools::handle;
+using datatools::make_handle;
+
+void test()
+{
+  // Test basic/copy construction/destruction
+  {
+      auto a = make_handle<int>(2);
+      {
+          auto b{a};
+          DT_THROW_IF(a.use_count() != 2, std::logic_error, "Copy of handle does not increment use_count");
+      }
+      DT_THROW_IF(a.use_count() != 1, std::logic_error, "Destruction of handle does not decrement use_count");
+  }
+
+  // Test move construction
+  {
+      auto a = make_handle<double>(3.14);
+      auto b{std::move(a)};
+
+      DT_THROW_IF(a, std::logic_error, "Moved handle still holds data");
+      DT_THROW_IF(a.use_count() != 0, std::logic_error, "Moved handle has non-null use count");
+
+      DT_THROW_IF(!b, std::logic_error, "Move constructed handle does not hold data");
+      DT_THROW_IF(b.use_count() != 1, std::logic_error, "Move constructed handle has incorrect use count");
+  }
+
+  // Test move assignment
+  {
+      auto a = make_handle<std::string>("hello");
+      auto b = std::move(a);
+      DT_THROW_IF(a, std::logic_error, "Moved handle still holds data");
+      DT_THROW_IF(a.use_count() != 0, std::logic_error, "Moved handle has non-null use count");
+
+      DT_THROW_IF(!b, std::logic_error, "Move assigned handle does not hold data");
+      DT_THROW_IF(b.use_count() != 1, std::logic_error, "Move assigned handle has incorrect use count");
+  }
+}
+
+int main()
+{
+    try 
+    {
+        test();
+    }
+    catch (std::exception& e)
+    {
+        std::cerr << "test_handle_construction::test() failed:\n" << e.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}

--- a/source/bxdatatools_module.cmake
+++ b/source/bxdatatools_module.cmake
@@ -456,6 +456,7 @@ ${module_test_dir}/test_cloneable_2.cxx
 ${module_test_dir}/test_cloneable.cxx
 ${module_test_dir}/test_data_serialization.cxx
 ${module_test_dir}/test_dummy_service.cxx
+${module_test_dir}/test_event_id.cxx
 ${module_test_dir}/test_exception.cxx
 ${module_test_dir}/test_factory.cxx
 ${module_test_dir}/test_handle_1.cxx
@@ -549,7 +550,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     ${module_test_dir}/test_introspection_data_description.cxx
     ${module_test_dir}/test_introspection_argument.cxx
     ${module_test_dir}/test_introspection_method.cxx
-    ${module_test_dir}/test_event_id.cxx
     )
 endif()
 

--- a/source/bxdatatools_module.cmake
+++ b/source/bxdatatools_module.cmake
@@ -462,6 +462,7 @@ ${module_test_dir}/test_factory.cxx
 ${module_test_dir}/test_handle_1.cxx
 ${module_test_dir}/test_handle_2.cxx
 ${module_test_dir}/test_handle_3.cxx
+${module_test_dir}/test_handle_construction.cxx
 ${module_test_dir}/test_handle_macros.cxx
 ${module_test_dir}/test_handle_operators.cxx
 ${module_test_dir}/test_integer_range.cxx

--- a/source/bxgeomtools/include/geomtools/base_hit.h
+++ b/source/bxgeomtools/include/geomtools/base_hit.h
@@ -117,10 +117,22 @@ namespace geomtools {
     void invalidate_auxiliaries ();
 
     /// Default constructor
-    base_hit ();
+    base_hit() = default;
 
     /// Destructor
-    virtual ~base_hit ();
+    virtual ~base_hit() = default;
+
+    /// Copy constructor
+    base_hit(const base_hit&) = default;
+
+    /// Copy assignment
+    base_hit& operator=(const base_hit& rhs) = default;
+
+    /// Move constructor
+    base_hit(base_hit&&) = default;
+
+    /// Move assignment
+    base_hit& operator=(base_hit&&) = default;
 
     /// Check if the hit is valid
     /** We consider a base hit valid if:
@@ -358,13 +370,13 @@ namespace geomtools {
      * the hit. It is made protected in order to allow
      * daughter classes to use it (32 bits are available)
      */
-    uint32_t              _store;
+    uint32_t              _store = STORE_NOTHING;
 
   private:
 
-    int32_t               _hit_id_;      //!< Unique hit ID
-    geomtools::geom_id    _geom_id_;     //!< Geometry ID
-    datatools::properties _auxiliaries_; //!< Auxiliary properties
+    int32_t               _hit_id_ = INVALID_HIT_ID;      //!< Unique hit ID
+    geomtools::geom_id    _geom_id_{};     //!< Geometry ID
+    datatools::properties _auxiliaries_{}; //!< Auxiliary properties
 
     DATATOOLS_SERIALIZATION_DECLARATION()
 

--- a/source/bxgeomtools/include/geomtools/base_hit.h
+++ b/source/bxgeomtools/include/geomtools/base_hit.h
@@ -126,7 +126,7 @@ namespace geomtools {
     base_hit(const base_hit&) = default;
 
     /// Copy assignment
-    base_hit& operator=(const base_hit& rhs) = default;
+    base_hit& operator=(const base_hit&) = default;
 
     /// Move constructor
     base_hit(base_hit&&) = default;

--- a/source/bxgeomtools/include/geomtools/geom_id.h
+++ b/source/bxgeomtools/include/geomtools/geom_id.h
@@ -144,7 +144,19 @@ namespace geomtools {
              uint32_t si9_ = INVALID_ADDRESS);
 
     /// Destructor
-    virtual ~geom_id ();
+    virtual ~geom_id () = default;
+
+    /// Copy constructor
+    geom_id(const geom_id&) = default;
+
+    /// Copy assignment
+    geom_id& operator=(const geom_id& rhs) = default;
+
+    /// Move constructor
+    geom_id(geom_id&&) = default;
+
+    /// Move assignment
+    geom_id& operator=(geom_id&&) = default; 
 
     /// Reset/invalidate the GID
     void reset ();

--- a/source/bxgeomtools/include/geomtools/geom_id.h
+++ b/source/bxgeomtools/include/geomtools/geom_id.h
@@ -150,7 +150,7 @@ namespace geomtools {
     geom_id(const geom_id&) = default;
 
     /// Copy assignment
-    geom_id& operator=(const geom_id& rhs) = default;
+    geom_id& operator=(const geom_id&) = default;
 
     /// Move constructor
     geom_id(geom_id&&) = default;

--- a/source/bxgeomtools/src/base_hit.cc
+++ b/source/bxgeomtools/src/base_hit.cc
@@ -136,20 +136,6 @@ namespace geomtools {
     return;
   }
 
-  base_hit::base_hit()
-  {
-    _store = STORE_NOTHING;
-    _hit_id_ = INVALID_HIT_ID;
-    _geom_id_.invalidate();
-    return;
-  }
-
-  base_hit::~base_hit()
-  {
-    this->base_hit::invalidate();
-    return;
-  }
-
   bool base_hit::is_valid() const
   {
     // Should we consider only the need for a valid hit id and let the possibility for an

--- a/source/bxgeomtools/src/geom_id.cc
+++ b/source/bxgeomtools/src/geom_id.cc
@@ -229,12 +229,6 @@ namespace geomtools {
     return;
   }
 
-  geom_id::~geom_id()
-  {
-    _addresses_.clear();
-    return;
-  }
-
   void geom_id::reset()
   {
     _type_ = INVALID_TYPE;

--- a/source/bxmctools/include/mctools/base_step_hit.h
+++ b/source/bxmctools/include/mctools/base_step_hit.h
@@ -348,13 +348,13 @@ namespace mctools {
     base_step_hit(const base_step_hit&) = default;
 
     // Copy assignment
-    base_step_hit& operator=(const base_step_hit& rhs) = default;
+    base_step_hit& operator=(const base_step_hit&) = default;
 
     // Move constructor
     base_step_hit(base_step_hit&&);
 
     // Move assignment
-    base_step_hit& operator=(base_step_hit&& rhs) = default;
+    base_step_hit& operator=(base_step_hit&&) = default;
 
     /// Reset/invalidate the internal structure of the hit
     void reset();

--- a/source/bxmctools/include/mctools/base_step_hit.h
+++ b/source/bxmctools/include/mctools/base_step_hit.h
@@ -337,11 +337,24 @@ namespace mctools {
     /// Reset/invalidate the internal structure of the hit
     virtual void invalidate();
 
+
     /// Default constructor
-    base_step_hit();
+    base_step_hit() = default;
 
     // Destructor
-    virtual ~base_step_hit();
+    virtual ~base_step_hit() = default;
+
+    // Copy constructor
+    base_step_hit(const base_step_hit&) = default;
+
+    // Copy assignment
+    base_step_hit& operator=(const base_step_hit& rhs) = default;
+
+    // Move constructor
+    base_step_hit(base_step_hit&&);
+
+    // Move assignment
+    base_step_hit& operator=(base_step_hit&& rhs) = default;
 
     /// Reset/invalidate the internal structure of the hit
     void reset();
@@ -372,40 +385,39 @@ namespace mctools {
     void dump() const;
 
   private:
-
     // Attributes :
 
     // Original attributes in version 0:
-    geomtools::vector_3d         _position_start_; //!< Start position : beginning of the tiny track segment (step)
-    geomtools::vector_3d         _position_stop_;  //!< Stop position  : end of the tiny track segment (step)
-    double                       _time_start_;     //!< Start time at start position
-    double                       _time_stop_;      //!< Stop time at stop position
-    geomtools::vector_3d         _momentum_start_; //!< Momentum at start position
-    geomtools::vector_3d         _momentum_stop_;  //!< Momentum at stop position
-    double                       _energy_deposit_; //!< Energy deposit along the track segment (step)
-    std::string                  _particle_name_;  //!< Name of the particle associated to the hit
+    geomtools::vector_3d _position_start_ = geomtools::invalid_vector_3d(); //!< Start position : beginning of the tiny track segment (step)
+    geomtools::vector_3d _position_stop_ = geomtools::invalid_vector_3d();  //!< Stop position  : end of the tiny track segment (step)
+    double               _time_start_ = datatools::invalid_real();     //!< Start time at start position
+    double               _time_stop_ = datatools::invalid_real();      //!< Stop time at stop position
+    geomtools::vector_3d _momentum_start_ = geomtools::invalid_vector_3d(); //!< Momentum at start position
+    geomtools::vector_3d _momentum_stop_ = geomtools::invalid_vector_3d();  //!< Momentum at stop position
+    double               _energy_deposit_ = datatools::invalid_real(); //!< Energy deposit along the track segment (step)
+    std::string          _particle_name_ = "";  //!< Name of the particle associated to the hit
 
     // Original attributes in version 1:
-    double                       _biasing_weight_; //!< The biasing weight of the particle track
+    double               _biasing_weight_ = datatools::invalid_real(); //!< The biasing weight of the particle track
 
     // Added attributes in version 2:
-    double                       _kinetic_energy_start_;
-    double                       _kinetic_energy_stop_;
-    double                       _step_length_;
-    bool                         _entering_volume_flag_ = false; 
-    bool                         _leaving_volume_flag_ = false; 
-    std::string                  _creator_process_name_;
-    bool                         _primary_particle_flag_ = false; 
-    bool                         _major_track_flag_ = false; 
-    bool                         _delta_ray_from_alpha_flag_ = false; 
-    int                          _track_id_ = -1;
-    int                          _parent_track_id_ = -1;
-    std::string                  _material_name_;
-    std::string                  _sensitive_category_;
-    std::string                  _g4_volume_name_;
-    int                          _g4_volume_copy_number_ = -1;
-    std::string                  _hit_processor_;
-    bool                         _visu_highlight_ = false; 
+    double               _kinetic_energy_start_ = datatools::invalid_real();;
+    double               _kinetic_energy_stop_ = datatools::invalid_real();
+    double               _step_length_ = datatools::invalid_real();
+    bool                 _entering_volume_flag_ = false; 
+    bool                 _leaving_volume_flag_ = false; 
+    std::string          _creator_process_name_ = "";
+    bool                 _primary_particle_flag_ = false; 
+    bool                 _major_track_flag_ = false; 
+    bool                 _delta_ray_from_alpha_flag_ = false; 
+    int                  _track_id_ = -1;
+    int                  _parent_track_id_ = -1;
+    std::string          _material_name_ = "";
+    std::string          _sensitive_category_ = "";
+    std::string          _g4_volume_name_ = "";
+    int                  _g4_volume_copy_number_ = -1;
+    std::string          _hit_processor_ = "";
+    bool                 _visu_highlight_ = false; 
 
     DATATOOLS_SERIALIZATION_DECLARATION()
     

--- a/source/bxmctools/include/mctools/g4/sensitive_hit.h
+++ b/source/bxmctools/include/mctools/g4/sensitive_hit.h
@@ -39,10 +39,22 @@ namespace mctools {
       mctools::base_step_hit & grab_hit_data ();
 
       /// Default constructor
-      sensitive_hit ();
+      sensitive_hit() = default;
 
       /// Destructor
-      virtual ~sensitive_hit ();
+      virtual ~sensitive_hit() = default;
+
+      /// Copy Constructor
+      sensitive_hit(const sensitive_hit&) = default;
+
+      // Copy assignment
+      sensitive_hit& operator=(const sensitive_hit& rhs) = default;
+
+      // Move Constructor
+      sensitive_hit(sensitive_hit&&) = default;
+      
+      // Copy assignment
+      sensitive_hit& operator=(sensitive_hit&& rhs) = default;
 
       /// Reset to default values
       void reset ();

--- a/source/bxmctools/include/mctools/g4/sensitive_hit.h
+++ b/source/bxmctools/include/mctools/g4/sensitive_hit.h
@@ -48,13 +48,13 @@ namespace mctools {
       sensitive_hit(const sensitive_hit&) = default;
 
       // Copy assignment
-      sensitive_hit& operator=(const sensitive_hit& rhs) = default;
+      sensitive_hit& operator=(const sensitive_hit&) = default;
 
       // Move Constructor
       sensitive_hit(sensitive_hit&&) = default;
       
       // Copy assignment
-      sensitive_hit& operator=(sensitive_hit&& rhs) = default;
+      sensitive_hit& operator=(sensitive_hit&&) = default;
 
       /// Reset to default values
       void reset ();

--- a/source/bxmctools/include/mctools/g4/sensitive_hit_collection.h
+++ b/source/bxmctools/include/mctools/g4/sensitive_hit_collection.h
@@ -35,11 +35,19 @@ namespace mctools {
 
       typedef std::vector<sensitive_hit*> hit_collection_type;
 
-      sensitive_hit_collection ();
+      sensitive_hit_collection () = default;
 
       sensitive_hit_collection (G4String a_detector_name, G4String a_collection_name);
 
-      virtual ~sensitive_hit_collection ();
+      virtual ~sensitive_hit_collection () = default;
+
+      sensitive_hit_collection(const sensitive_hit_collection&) = default;
+      
+      sensitive_hit_collection& operator=(const sensitive_hit_collection&) = default;
+      
+      sensitive_hit_collection(sensitive_hit_collection&&) = default;
+      
+      sensitive_hit_collection& operator=(sensitive_hit_collection&&) = default;
 
       G4int operator==(const sensitive_hit_collection & right) const;
 

--- a/source/bxmctools/src/base_step_hit.cc
+++ b/source/bxmctools/src/base_step_hit.cc
@@ -788,20 +788,6 @@ namespace mctools {
   }
  
   /* General */
-  
-  base_step_hit::base_step_hit()
-    : geomtools::base_hit()
-  {
-    base_step_hit::reset();
-    return;
-  }
-
-  base_step_hit::~base_step_hit()
-  {
-    base_step_hit::reset();
-    return;
-  }
-
   bool base_step_hit::is_valid() const
   {
     // Only check ID, time and position but skip GID ?

--- a/source/bxmctools/src/g4/sensitive_hit.cc
+++ b/source/bxmctools/src/g4/sensitive_hit.cc
@@ -22,16 +22,6 @@ namespace mctools {
       return _hit_data_;
     }
 
-    sensitive_hit::sensitive_hit()
-    {
-       return;
-    }
-
-    sensitive_hit::~sensitive_hit()
-    {
-      return;
-    }
-
     void sensitive_hit::reset()
     {
       _hit_data_.reset();

--- a/source/bxmctools/src/g4/sensitive_hit_collection.cc
+++ b/source/bxmctools/src/g4/sensitive_hit_collection.cc
@@ -10,21 +10,10 @@ namespace mctools {
 
   namespace g4 {
 
-    sensitive_hit_collection::sensitive_hit_collection ()
-    {
-      return;
-    }
-
     sensitive_hit_collection::sensitive_hit_collection (G4String a_detector_name,
                                                         G4String a_collection_name)
       : G4VHitsCollection (a_detector_name, a_collection_name)
     {
-      return;
-    }
-
-    sensitive_hit_collection::~sensitive_hit_collection ()
-    {
-      _hits.clear ();
       return;
     }
 


### PR DESCRIPTION
To ensure that copying/moving data objects can be implemented as efficiently as possible, this Pull Request adds copy and move constructors and assignment operators for the most commonly used low level data objects in Bayeux (as identified in SuperNEMO's use).

All are defaulted following the ISO CPP Guidelines as they all model value types.  Whilst it's orthogonal to #49, many of the touched classes own `properties` instances so require the copy/move implemented in that Pull Request for maximum benefit.

SuperNEMO will require this change in order to properly modernise and develop our data model.
CC: @emchauve, @yramachers, @cherylepatrick