### PR TITLE
bug in time_slicer_generator.cc due to a typo

### DIFF
--- a/source/bxgenbb_help/src/time_slicer_generator.cc
+++ b/source/bxgenbb_help/src/time_slicer_generator.cc
@@ -335,7 +335,7 @@ namespace genbb {
 
         if (delayed_event.get_number_of_particles() > 0) {
           if (working_event.has_time()) {
-            delayed_event.set_time(working_event.get_time() + first_delayed_time);
+            delayed_event.set_time(working_event.get_time() - first_delayed_time);
           }
           delayed_event.shift_particles_time(-first_delayed_time);
           if (working_event.has_vertex()) {


### PR DESCRIPTION
correct a typo in time_slicer_generator.cc  : all particles of the delayed events must have their time shifted negatively from the first delayed time and not positively !