### PR TITLE
Address (most) warnings on Clang

### DIFF
--- a/source/bxbrio/include/brio/detail/TArrayCMod.h
+++ b/source/bxbrio/include/brio/detail/TArrayCMod.h
@@ -33,19 +33,19 @@ public:
 
 public:
   TArrayCMod();
-  virtual ~TArrayCMod();
+  ~TArrayCMod() override;
   void Reserve(Int_t n);
   void Clear();
-  void Set(Int_t n);
+  void Set(Int_t n) override;
 
   // Mandatory by TArray inheritance:
-  Double_t GetAt(Int_t /*i*/) const {return 0.0;}
-  void SetAt(Double_t /*x*/, Int_t /*i*/) {return;}
+  Double_t GetAt(Int_t /*i*/) const override {return 0.0;}
+  void SetAt(Double_t /*x*/, Int_t /*i*/) override {return;}
 
   // Workaround
 private:
   void _Streamer_(TBuffer &b);
-  ClassDef(TArrayCMod,1)  //Array of chars
+  ClassDefOverride(TArrayCMod,1)  //Array of chars
 };
 
 #endif // BRIO_DETAIL_TARRAYCMOD_H

--- a/source/bxbrio/include/brio/detail/base_io.h
+++ b/source/bxbrio/include/brio/detail/base_io.h
@@ -67,7 +67,7 @@ namespace brio {
 
       base_io(int rw_, int format_, datatools::logger::priority p_);
 
-      virtual ~base_io();
+      ~base_io() override;
 
       //! File open
       virtual void open(const std::string & filename_);
@@ -127,10 +127,10 @@ namespace brio {
 
       void get_list_of_stores(std::list<std::string> & list_) const;
 
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       void reset();
 

--- a/source/bxbrio/include/brio/detail/brio_record.h
+++ b/source/bxbrio/include/brio/detail/brio_record.h
@@ -55,12 +55,12 @@ public:
   brio_record();
 
   //! Destructor
-  virtual ~brio_record();
+  ~brio_record() override;
 
   //! Reset the internal data
   void reset();
 
-  ClassDef(brio_record,1) // Basic BRIO record
+  ClassDefOverride(brio_record,1) // Basic BRIO record
 
 };
 

--- a/source/bxbrio/include/brio/reader.h
+++ b/source/bxbrio/include/brio/reader.h
@@ -63,7 +63,7 @@ namespace brio {
            datatools::logger::priority p_ = datatools::logger::PRIO_FATAL);
 
     //! Destructor
-    virtual ~reader();
+    ~reader() override;
 
     /** By default, serialization tag are checked each time
      *  an object is deserialized.
@@ -113,16 +113,16 @@ namespace brio {
     int load(T & data_, const std::string & label_, int64_t nentry_ = -1);
 
     //! Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     //! Print
     void print_info(std::ostream& out_ = std::clog) const;
 
   protected:
-    virtual void _at_open(const std::string & filename_);
+    void _at_open(const std::string & filename_) override;
 
     template<class T>
     int _at_load(T & data_, store_info * ptr_si_, int64_t nentry_);

--- a/source/bxbrio/include/brio/writer.h
+++ b/source/bxbrio/include/brio/writer.h
@@ -63,7 +63,7 @@ namespace brio {
            datatools::logger::priority p_ = datatools::logger::PRIO_FATAL);
 
     //! Destructor
-    virtual ~writer();
+    ~writer() override;
 
     //! Lock the writer
     void lock();
@@ -125,10 +125,10 @@ namespace brio {
     int store(const T & data_, const std::string & label_ = "");
 
     //! Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     //! Print
     void print_info(std::ostream & out_ = std::clog) const;
@@ -144,7 +144,7 @@ namespace brio {
     template <typename T>
     int _at_store(const T & dat, store_info * store_info_);
 
-    virtual void _at_open(const std::string & filename_);
+    void _at_open(const std::string & filename_) override;
 
   private:
 

--- a/source/bxcuts/include/cuts/accept_cut.h
+++ b/source/bxcuts/include/cuts/accept_cut.h
@@ -30,20 +30,20 @@ namespace cuts {
                datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~accept_cut();
+    ~accept_cut() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties &,
+    void initialize(const datatools::properties &,
                             datatools::service_manager &,
-                            cuts::cut_handle_dict_type &);
+                            cuts::cut_handle_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/and_cut.h
+++ b/source/bxcuts/include/cuts/and_cut.h
@@ -30,12 +30,12 @@ namespace cuts {
             datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~and_cut();
+    ~and_cut() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/cut_manager.h
+++ b/source/bxcuts/include/cuts/cut_manager.h
@@ -114,7 +114,7 @@ namespace cuts {
     cut_manager(uint32_t the_flags = BLANK);
 
     /// Destructor
-    virtual ~cut_manager();
+    ~cut_manager() override;
 
     /// Check availability of the service manager
     bool has_service_manager() const;
@@ -132,10 +132,10 @@ namespace cuts {
     void install_service_manager(const datatools::properties & a_service_manager_configuration);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & a_out         = std::clog,
+    void tree_dump(std::ostream & a_out         = std::clog,
                            const std::string & a_title  = "",
                            const std::string & a_indent = "",
-                           bool a_inherit          = false) const;
+                           bool a_inherit          = false) const override;
 
     /// Print report
     void print_report(std::ostream & a_out = std::clog) const;

--- a/source/bxcuts/include/cuts/cut_service.h
+++ b/source/bxcuts/include/cuts/cut_service.h
@@ -67,26 +67,26 @@ namespace cuts {
     void set_cut_manager (const cut_manager & a_cut_manager);
 
     /// Check the initialization status
-    virtual bool is_initialized () const;
+    bool is_initialized () const override;
 
     /// Initialize the service through a collection of setup properties
-    virtual int initialize (const datatools::properties & a_config,
-                            datatools::service_dict_type & a_service_dict);
+    int initialize (const datatools::properties & a_config,
+                            datatools::service_dict_type & a_service_dict) override;
 
     /// Reset
-    virtual int reset ();
+    int reset () override;
 
     /// Constructor
     cut_service ();
 
     /// Destructor
-    virtual ~cut_service ();
+    ~cut_service () override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & a_out         = std::clog,
+    void tree_dump (std::ostream & a_out         = std::clog,
                             const std::string & a_title  = "",
                             const std::string & a_indent = "",
-                            bool a_inherit               = false) const;
+                            bool a_inherit               = false) const override;
 
   private:
 

--- a/source/bxcuts/include/cuts/cut_tools.h
+++ b/source/bxcuts/include/cuts/cut_tools.h
@@ -153,10 +153,10 @@ namespace cuts {
     cut_handle_type & grab_initialized_cut_handle();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   private:
 

--- a/source/bxcuts/include/cuts/exclude_cut.h
+++ b/source/bxcuts/include/cuts/exclude_cut.h
@@ -30,12 +30,12 @@ namespace cuts {
             datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~exclude_cut();
+    ~exclude_cut() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/i_binary_cut.h
+++ b/source/bxcuts/include/cuts/i_binary_cut.h
@@ -43,35 +43,35 @@ namespace cuts {
                  datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~i_binary_cut();
+    ~i_binary_cut() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties &,
+    void initialize(const datatools::properties &,
                             datatools::service_manager &,
-                            cuts::cut_handle_dict_type &);
+                            cuts::cut_handle_dict_type &) override;
 
     /// Export to a container of properties
-    virtual void export_to_config(datatools::properties & config_,
+    void export_to_config(datatools::properties & config_,
                                   uint32_t flags_ = i_cut::EXPORT_CONFIG_DEFAULT,
-                                  const std::string & prefix_ = "") const;
+                                  const std::string & prefix_ = "") const override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & a_out         = std::clog,
+    void tree_dump (std::ostream & a_out         = std::clog,
                             const std::string & a_title  = "",
                             const std::string & a_indent = "",
-                            bool a_inherit               = false) const;
+                            bool a_inherit               = false) const override;
 
   protected:
 
     void _install_cuts(const datatools::properties & a_configuration,
                        cuts::cut_handle_dict_type & a_cut_dict);
 
-    virtual void _at_set_user_data();
+    void _at_set_user_data() override;
 
-    virtual void _at_reset_user_data();
+    void _at_reset_user_data() override;
 
     void _reset_cuts();
 

--- a/source/bxcuts/include/cuts/i_cut.h
+++ b/source/bxcuts/include/cuts/i_cut.h
@@ -82,17 +82,17 @@ namespace cuts {
                     );
         return *_address;
       }
-      virtual const std::type_info * get_typeinfo() const {
+      const std::type_info * get_typeinfo() const override {
         return _ti;
       }
-      virtual bool match(const std::type_info * tit_) const {
+      bool match(const std::type_info * tit_) const override {
         return tit_ == _ti;
       }
       void set(const T & obj) {
         _address = &obj;
         _ti = &typeid(T);
       }
-      virtual operator bool() const {
+      operator bool() const override {
         return _address != 0 && _ti != 0;
       }
       void reset() {
@@ -106,7 +106,7 @@ namespace cuts {
       referenced_data(const T & obj) {
         set(obj);
       }
-      virtual ~referenced_data() {
+      ~referenced_data() override {
         _address = 0;
         _ti = 0;
       }
@@ -293,13 +293,13 @@ namespace cuts {
     explicit i_cut(datatools::logger::priority p = datatools::logger::PRIO_FATAL);
 
     //! Destructor
-    virtual ~i_cut();
+    ~i_cut() override;
 
     //! Smart print
-    virtual void tree_dump(std::ostream & a_out         = std::clog,
+    void tree_dump(std::ostream & a_out         = std::clog,
                            const std::string & a_title  = "",
                            const std::string & a_indent = "",
-                           bool a_inherit          = false) const;
+                           bool a_inherit          = false) const override;
 
     //! Print shortcut @see tree_dump()
     void print(std::ostream & a_out = std::clog) const;
@@ -410,7 +410,7 @@ namespace cuts {
 /** Interface macro for automated registration of a cut class in the global register */
 #define CUT_REGISTRATION_INTERFACE(T)           \
   public:                                       \
-  virtual std::string get_type_id() const; \
+  std::string get_type_id() const override; \
   private:                                                                \
   DATATOOLS_FACTORY_SYSTEM_AUTO_REGISTRATION_INTERFACE(::cuts::i_cut, T) \
   /**/

--- a/source/bxcuts/include/cuts/i_multi_cut.h
+++ b/source/bxcuts/include/cuts/i_multi_cut.h
@@ -44,29 +44,29 @@ namespace cuts {
                  datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~i_multi_cut();
+    ~i_multi_cut() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties &,
+    void initialize(const datatools::properties &,
                             datatools::service_manager &,
-                            cuts::cut_handle_dict_type &);
+                            cuts::cut_handle_dict_type &) override;
 
     /// Export to a container of properties
-    virtual void export_to_config(datatools::properties & config_,
+    void export_to_config(datatools::properties & config_,
                                   uint32_t flags_ = i_cut::EXPORT_CONFIG_DEFAULT,
-                                  const std::string & prefix_ = "") const;
+                                  const std::string & prefix_ = "") const override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
   protected:
 
     void _install_cuts(const datatools::properties & a_configuration,
                        cuts::cut_handle_dict_type & a_cut_dict);
 
-    virtual void _at_set_user_data();
+    void _at_set_user_data() override;
 
-    virtual void _at_reset_user_data();
+    void _at_reset_user_data() override;
 
     void _reset_cuts();
 

--- a/source/bxcuts/include/cuts/multi_and_cut.h
+++ b/source/bxcuts/include/cuts/multi_and_cut.h
@@ -34,12 +34,12 @@ namespace cuts {
                   datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~multi_and_cut();
+    ~multi_and_cut() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/multi_or_cut.h
+++ b/source/bxcuts/include/cuts/multi_or_cut.h
@@ -34,12 +34,12 @@ namespace cuts {
                  datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~multi_or_cut();
+    ~multi_or_cut() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/multi_xor_cut.h
+++ b/source/bxcuts/include/cuts/multi_xor_cut.h
@@ -34,12 +34,12 @@ namespace cuts {
                  datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~multi_xor_cut();
+    ~multi_xor_cut() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/nand_cut.h
+++ b/source/bxcuts/include/cuts/nand_cut.h
@@ -29,12 +29,12 @@ namespace cuts {
              datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~nand_cut();
+    ~nand_cut() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/nor_cut.h
+++ b/source/bxcuts/include/cuts/nor_cut.h
@@ -31,12 +31,12 @@ namespace cuts {
             datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~nor_cut();
+    ~nor_cut() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/not_cut.h
+++ b/source/bxcuts/include/cuts/not_cut.h
@@ -32,31 +32,31 @@ namespace cuts {
             datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~not_cut();
+    ~not_cut() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties &,
+    void initialize(const datatools::properties &,
                             datatools::service_manager &,
-                            cuts::cut_handle_dict_type &);
+                            cuts::cut_handle_dict_type &) override;
 
     /// Export to a container of properties
-    virtual void export_to_config(datatools::properties & config_,
+    void export_to_config(datatools::properties & config_,
                                   uint32_t flags_ = i_cut::EXPORT_CONFIG_DEFAULT,
-                                  const std::string & prefix_ = "") const;
+                                  const std::string & prefix_ = "") const override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   protected:
 
-    virtual void _at_set_user_data();
+    void _at_set_user_data() override;
 
-    virtual void _at_reset_user_data();
+    void _at_reset_user_data() override;
 
   protected:
 

--- a/source/bxcuts/include/cuts/or_cut.h
+++ b/source/bxcuts/include/cuts/or_cut.h
@@ -30,12 +30,12 @@ namespace cuts {
             datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~or_cut();
+    ~or_cut() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/random_cut.h
+++ b/source/bxcuts/include/cuts/random_cut.h
@@ -38,20 +38,20 @@ namespace cuts {
                datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~random_cut();
+    ~random_cut() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties &,
+    void initialize(const datatools::properties &,
                             datatools::service_manager &,
-                            cuts::cut_handle_dict_type &);
+                            cuts::cut_handle_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/reject_cut.h
+++ b/source/bxcuts/include/cuts/reject_cut.h
@@ -31,20 +31,20 @@ namespace cuts {
                datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~reject_cut();
+    ~reject_cut() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties &,
+    void initialize(const datatools::properties &,
                             datatools::service_manager &,
-                            cuts::cut_handle_dict_type &);
+                            cuts::cut_handle_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/xnor_cut.h
+++ b/source/bxcuts/include/cuts/xnor_cut.h
@@ -30,12 +30,12 @@ namespace cuts {
              datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~xnor_cut();
+    ~xnor_cut() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/include/cuts/xor_cut.h
+++ b/source/bxcuts/include/cuts/xor_cut.h
@@ -30,12 +30,12 @@ namespace cuts {
             datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~xor_cut();
+    ~xor_cut() override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxcuts/testing/cuts_test_color_cut.h
+++ b/source/bxcuts/testing/cuts_test_color_cut.h
@@ -39,25 +39,25 @@ namespace cuts {
       color_cut(datatools::logger::priority a_logging_priority =
             datatools::logger::PRIO_FATAL);
 
-      virtual ~color_cut();
+      ~color_cut() override;
 
       /// Initialization
-      virtual void initialize(const datatools::properties &,
-                              datatools::service_manager &,
-                              cuts::cut_handle_dict_type &);
+      void initialize(const datatools::properties &,
+                      datatools::service_manager &,
+                      cuts::cut_handle_dict_type &) override;
 
       /// Export to a container of properties
-      virtual void export_to_config(datatools::properties & config_,
-                                    uint32_t flags_ = i_cut::EXPORT_CONFIG_DEFAULT,
-                                    const std::string & prefix_ = "") const;
+      void export_to_config(datatools::properties & config_,
+                            uint32_t flags_ = i_cut::EXPORT_CONFIG_DEFAULT,
+                            const std::string & prefix_ = "") const override;
 
       /// Reset
-      virtual void reset();
+      void reset() override;
 
     protected :
 
       /// Selection
-      virtual int _accept();
+      int _accept() override;
 
     private:
 

--- a/source/bxcuts/testing/cuts_test_range_cut.h
+++ b/source/bxcuts/testing/cuts_test_range_cut.h
@@ -63,25 +63,25 @@ namespace cuts {
                  = datatools::logger::PRIO_FATAL);
 
       // CUT_DESTRUCTOR_DECLARE (range_cut)
-      virtual ~range_cut ();
+      ~range_cut() override;
 
       // CUT_INITIALIZE_DECLARE()
-      virtual void initialize (const datatools::properties &,
-                               datatools::service_manager &,
-                               cuts::cut_handle_dict_type &);
+      void initialize (const datatools::properties &,
+                       datatools::service_manager &,
+                       cuts::cut_handle_dict_type &) override;
 
       /// Export to a container of properties
-      virtual void export_to_config(datatools::properties & config_,
-                                    uint32_t flags_ = i_cut::EXPORT_CONFIG_DEFAULT,
-                                    const std::string & prefix_ = "") const;
+      void export_to_config(datatools::properties & config_,
+                            uint32_t flags_ = i_cut::EXPORT_CONFIG_DEFAULT,
+                            const std::string & prefix_ = "") const override;
 
       // CUT_RESET_DECLARE();
-      virtual void reset ();
+      void reset() override;
 
     protected :
 
       // CUT_ACCEPT_DECLARE();
-      virtual int _accept ();
+      int _accept() override;
 
     private:
 

--- a/source/bxcuts/testing/cuts_test_sphere_cut.h
+++ b/source/bxcuts/testing/cuts_test_sphere_cut.h
@@ -46,25 +46,25 @@ namespace cuts {
       sphere_cut(datatools::logger::priority a_logging_priority =
                  datatools::logger::PRIO_FATAL);
 
-      virtual ~sphere_cut();
+      ~sphere_cut() override;
 
       /// Initialization
-      virtual void initialize(const datatools::properties &,
-                              datatools::service_manager &,
-                              cuts::cut_handle_dict_type &);
+      void initialize(const datatools::properties &,
+                      datatools::service_manager &,
+                      cuts::cut_handle_dict_type &) override;
 
       /// Export to a container of properties
-      virtual void export_to_config(datatools::properties & config_,
-                                    uint32_t flags_ = i_cut::EXPORT_CONFIG_DEFAULT,
-                                    const std::string & prefix_ = "") const;
+      void export_to_config(datatools::properties & config_,
+                            uint32_t flags_ = i_cut::EXPORT_CONFIG_DEFAULT,
+                            const std::string & prefix_ = "") const override;
 
       /// Reset
-      virtual void reset();
+      void reset() override;
 
     protected :
 
       /// Selection
-      virtual int _accept();
+      int _accept() override;
 
     private:
 

--- a/source/bxdatatools/include/datatools/base_service.h
+++ b/source/bxdatatools/include/datatools/base_service.h
@@ -80,7 +80,7 @@ namespace datatools {
                  logger::priority lp_ = logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~base_service();
+    ~base_service() override;
 
     /// Undocumented unused/unimplemented method
     virtual void fetch_dependencies(service_dependency_dict_type & /*dependencies_*/) const;
@@ -153,7 +153,7 @@ DR_CLASS_INIT(datatools::base_service)
   private:                                                              \
   DATATOOLS_FACTORY_SYSTEM_AUTO_REGISTRATION_INTERFACE(::datatools::base_service, SERVICE_CLASS_NAME) \
   public:                                                               \
-  virtual std::string service_class_id() const;                         \
+  std::string service_class_id() const override;                         \
   /**/
 
 #define DATATOOLS_SERVICE_REGISTRATION_IMPLEMENT(SERVICE_CLASS_NAME,SERVICE_ID) \

--- a/source/bxdatatools/include/datatools/command_utils.h
+++ b/source/bxdatatools/include/datatools/command_utils.h
@@ -74,6 +74,9 @@ namespace datatools {
       CEC_PARAMETER_INVALID_UNIT       = 37  //!< Invalid parameter unit (for real numbers)
     };
 
+    // CAMP classes with RTTI imply inheritance
+    virtual ~command() = default;
+
     /// \brief Command returned information
     class returned_info
     {
@@ -88,8 +91,8 @@ namespace datatools {
       /// Constructor of a failed command returned info
       returned_info(error_code_type code_, const std::string & message_ = "");
 
-      /// Destructor
-      ~returned_info();
+      /// Destructor (must be virtual for use with CAMP RTTI)
+      virtual ~returned_info();
 
       /// Set continue code
       void set_continue();

--- a/source/bxdatatools/include/datatools/configuration/array_occurrence.h
+++ b/source/bxdatatools/include/datatools/configuration/array_occurrence.h
@@ -58,22 +58,22 @@ namespace datatools {
       array_occurrence();
 
       /// Destructor
-      virtual ~array_occurrence();
+      ~array_occurrence() override;
 
       /// Return the dimension
-      virtual size_t get_dimension() const;
+      size_t get_dimension() const override;
 
       /// Return the number of occurrences
-      virtual size_t get_number_of_occurrences() const;
+      size_t get_number_of_occurrences() const override;
 
       /// Compute the occurrence associated to a given rank
-      virtual void compute_occurrence(int rank_, single_occurrence & occ_) const;
+      void compute_occurrence(int rank_, single_occurrence & occ_) const override;
 
       /// Compute a multidimensional index path from a rank
-      virtual size_t compute_index_path(std::vector<uint32_t> & path_, int rank_) const;
+      size_t compute_index_path(std::vector<uint32_t> & path_, int rank_) const override;
 
       /// Convert to a string
-      virtual std::string to_string() const;
+      std::string to_string() const override;
 
     private:
 

--- a/source/bxdatatools/include/datatools/configuration/parameter_model.h
+++ b/source/bxdatatools/include/datatools/configuration/parameter_model.h
@@ -68,7 +68,7 @@ namespace datatools {
       };
 
       /// Check if a name is valid
-      virtual bool is_name_valid(const std::string & name_) const;
+      bool is_name_valid(const std::string & name_) const override;
 
       /// Dictionary of variant physicals
       typedef std::map<std::string, variant_physical> variant_dict_type;
@@ -186,10 +186,10 @@ namespace datatools {
         void reset();
 
         /// Smart print
-        virtual void tree_dump(std::ostream & out_ = std::clog,
+        void tree_dump(std::ostream & out_ = std::clog,
                                const std::string & title_ = "",
                                const std::string & indent_ = "",
-                               bool inherit_ = false) const;
+                               bool inherit_ = false) const override;
 
         /// \brief Restructured text formatting
         enum rst_flags {
@@ -248,7 +248,7 @@ namespace datatools {
       parameter_model();
 
       /// Destructor
-      virtual ~parameter_model();
+      ~parameter_model() override;
 
       /// Check if the documentation is empty
       bool has_documentation() const;
@@ -678,10 +678,10 @@ namespace datatools {
       void reset();
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// Check if a boolean value is valid
       bool is_boolean_valid(const bool) const;

--- a/source/bxdatatools/include/datatools/configuration/parameter_physical.h
+++ b/source/bxdatatools/include/datatools/configuration/parameter_physical.h
@@ -55,13 +55,13 @@ namespace datatools {
     public:
 
       /// Check if a name is valid
-      virtual bool is_name_valid(const std::string & name_) const;
+      bool is_name_valid(const std::string & name_) const override;
 
       /// Default constructeur
       parameter_physical();
 
       /// Destructeur
-      ~parameter_physical();
+      ~parameter_physical() override;
 
       /// Reset
       void reset();
@@ -78,10 +78,10 @@ namespace datatools {
       const pm_handle_type & get_model_handle() const;
 
       /// Smart print
-      virtual void tree_dump(std::ostream& out_ = std::clog,
+      void tree_dump(std::ostream& out_ = std::clog,
                              const std::string& title_  = "",
                              const std::string& indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// Check occurrence
       bool has_occurrence() const;

--- a/source/bxdatatools/include/datatools/configuration/single_occurrence.h
+++ b/source/bxdatatools/include/datatools/configuration/single_occurrence.h
@@ -58,22 +58,22 @@ namespace datatools {
       single_occurrence();
 
       /// Destructor
-      virtual ~single_occurrence();
+      ~single_occurrence() override;
 
       /// Return the dimension
-      virtual size_t get_dimension() const;
+      size_t get_dimension() const override;
 
       /// Return the number of occurrences
-      virtual size_t get_number_of_occurrences() const;
+      size_t get_number_of_occurrences() const override;
 
       /// Compute the occurrence associated to a given rank
-      virtual void compute_occurrence(int rank_, single_occurrence & occ_) const;
+      void compute_occurrence(int rank_, single_occurrence & occ_) const override;
 
       /// Compute a multidimensional index path from a rank
-      virtual size_t compute_index_path(std::vector<uint32_t> & path_, int rank_) const;
+      size_t compute_index_path(std::vector<uint32_t> & path_, int rank_) const override;
 
       /// Convert to a string
-      virtual std::string to_string() const;
+      std::string to_string() const override;
 
     private:
 

--- a/source/bxdatatools/include/datatools/configuration/variant_dependency.h
+++ b/source/bxdatatools/include/datatools/configuration/variant_dependency.h
@@ -100,7 +100,7 @@ namespace datatools {
       variant_dependency(const variant_registry & registry_);
 
       /// Destructor
-      ~variant_dependency();
+      ~variant_dependency() override;
 
       /// Check repository
       bool has_repository() const;
@@ -159,10 +159,10 @@ namespace datatools {
       const variant_object_info & get_dependee(const unsigned int slot_) const;
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// Instantiate the embedded predicate:
       base_dependency_logic & create_logic(const std::string & guid_);

--- a/source/bxdatatools/include/datatools/configuration/variant_dependency_logic.h
+++ b/source/bxdatatools/include/datatools/configuration/variant_dependency_logic.h
@@ -64,7 +64,7 @@ namespace datatools {
       base_dependency_logic(variant_dependency &);
 
       /// Destructor
-      virtual ~base_dependency_logic();
+      ~base_dependency_logic() override;
 
       /// Return the global unique class identifier
       virtual const char * guid() const = 0;
@@ -100,10 +100,10 @@ namespace datatools {
       const variant_repository & get_repository() const;
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// Return the const reference to the owner dependency
       const variant_dependency & get_owner_dependency() const;
@@ -144,31 +144,31 @@ namespace datatools {
       slot_logic(variant_dependency &);
 
       /// Destructor
-      virtual ~slot_logic();
+      ~slot_logic() override;
 
       /// Return the global unique class identifier
-      virtual const char * guid() const;
+      const char * guid() const override;
 
       /// Return the minimum number of input ports
-      virtual std::size_t min_ports() const;
+      std::size_t min_ports() const override;
 
       /// Return the maximum number of input ports
-      virtual std::size_t max_ports() const;
+      std::size_t max_ports() const override;
 
       /// Check validity
-      virtual bool is_valid() const;
+      bool is_valid() const override;
 
       /// Check the logic
-      virtual bool operator()() const;
+      bool operator()() const override;
 
       /// Set the slot identifier of the dependee
       void set_dependee_slot(const unsigned int dependee_slot_);
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
     private:
 
       unsigned int _dependee_slot_
@@ -185,16 +185,16 @@ namespace datatools {
       not_logic(variant_dependency &);
 
       /// Destructor
-      virtual ~not_logic();
+      ~not_logic() override;
 
       /// Return the global unique class identifier
-      virtual const char * guid() const;
+      const char * guid() const override;
 
       /// Return the maximum number of input ports
-      virtual std::size_t max_ports() const;
+      std::size_t max_ports() const override;
 
       /// Check the logic
-      virtual bool operator()() const;
+      bool operator()() const override;
 
     };
 
@@ -207,13 +207,13 @@ namespace datatools {
       and_logic(variant_dependency &);
 
       /// Destructor
-      virtual ~and_logic();
+      ~and_logic() override;
 
       /// Return the global unique class identifier
-      virtual const char * guid() const;
+      const char * guid() const override;
 
       /// Check the logic
-      virtual bool operator()() const;
+      bool operator()() const override;
 
     };
 
@@ -226,13 +226,13 @@ namespace datatools {
       or_logic(variant_dependency &);
 
       /// Destructor
-      virtual ~or_logic();
+      ~or_logic() override;
 
       /// Return the global unique class identifier
-      virtual const char * guid() const;
+      const char * guid() const override;
 
       /// Check the logic
-      virtual bool operator()() const;
+      bool operator()() const override;
 
     };
 
@@ -245,13 +245,13 @@ namespace datatools {
       xor_logic(variant_dependency &);
 
       /// Destructor
-      virtual ~xor_logic();
+      ~xor_logic() override;
 
       /// Return the global unique class identifier
-      virtual const char * guid() const;
+      const char * guid() const override;
 
       /// Check the logic
-      virtual bool operator()() const;
+      bool operator()() const override;
 
     };
 

--- a/source/bxdatatools/include/datatools/configuration/variant_dependency_model.h
+++ b/source/bxdatatools/include/datatools/configuration/variant_dependency_model.h
@@ -187,10 +187,10 @@ namespace datatools {
       void reset();
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// Check if a dependency is associated to a variant object given its path
       bool has_dependency(const std::string & path_) const;

--- a/source/bxdatatools/include/datatools/configuration/variant_model.h
+++ b/source/bxdatatools/include/datatools/configuration/variant_model.h
@@ -62,7 +62,7 @@ namespace datatools {
     public:
 
       /// Check if a name is valid
-      virtual bool is_name_valid(const std::string & name_) const;
+      bool is_name_valid(const std::string & name_) const override;
 
       /// \brief Parameter record
       struct parameter_record {
@@ -79,7 +79,7 @@ namespace datatools {
       variant_model();
 
       /// Destructor
-      virtual ~variant_model();
+      ~variant_model() override;
 
       /// Check if the documentation is empty
       bool has_documentation() const;
@@ -134,10 +134,10 @@ namespace datatools {
       const i_occurrence & get_parameter_occurrence(const std::string & parameter_name_) const;
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// \brief ReST formating flags
       enum rst_flags {

--- a/source/bxdatatools/include/datatools/configuration/variant_physical.h
+++ b/source/bxdatatools/include/datatools/configuration/variant_physical.h
@@ -51,13 +51,13 @@ namespace datatools {
     public:
 
       /// Check if a name is valid
-      virtual bool is_name_valid(const std::string & name_) const;
+      bool is_name_valid(const std::string & name_) const override;
 
       /// Default constructeur
       variant_physical();
 
       /// Destructeur
-      ~variant_physical();
+      ~variant_physical() override;
 
       /// Set the physical
       void set(const std::string & name_,
@@ -71,10 +71,10 @@ namespace datatools {
       const vm_handle_type & get_model_handle() const;
 
       /// Smart print
-      virtual void tree_dump(std::ostream& out_ = std::clog,
+      void tree_dump(std::ostream& out_ = std::clog,
                              const std::string& title_  = "",
                              const std::string& indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     private:
 

--- a/source/bxdatatools/include/datatools/configuration/variant_registry.h
+++ b/source/bxdatatools/include/datatools/configuration/variant_registry.h
@@ -61,13 +61,13 @@ namespace datatools {
       static const std::string & default_top_variant_name();
 
       /// Check if a name is valid
-      virtual bool is_name_valid(const std::string & name_) const;
+      bool is_name_valid(const std::string & name_) const override;
 
       /// Default constructor
       variant_registry();
 
       /// Destructor
-      virtual ~variant_registry();
+      ~variant_registry() override;
 
       /// Check if the top variant name is set
       bool has_top_variant_name() const;
@@ -158,10 +158,10 @@ namespace datatools {
       void load_local_dependency_model(const datatools::properties & ldm_config_);
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & inden_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// \brief Flags for building the list of parameters
       enum list_flags {

--- a/source/bxdatatools/include/datatools/configuration/variant_registry_manager.h
+++ b/source/bxdatatools/include/datatools/configuration/variant_registry_manager.h
@@ -56,7 +56,7 @@ namespace datatools {
       variant_registry_manager();
 
       /// Destructor
-      virtual ~variant_registry_manager();
+      ~variant_registry_manager() override;
 
       /// Check initialization status
       bool is_initialized() const;
@@ -92,10 +92,10 @@ namespace datatools {
       const model_item_dict_type & get_configuration_items() const;
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// OCD support
       static void init_ocd(datatools::object_configuration_description &);

--- a/source/bxdatatools/include/datatools/configuration/variant_repository.h
+++ b/source/bxdatatools/include/datatools/configuration/variant_repository.h
@@ -154,13 +154,13 @@ namespace datatools {
       typedef std::map<int, std::string> ranked_dict_type;
 
       /// Check if a name is valid
-      virtual bool is_name_valid(const std::string & name_) const;
+      bool is_name_valid(const std::string & name_) const override;
 
       /// Default constructor
       variant_repository();
 
       /// Destructor
-      ~variant_repository();
+      ~variant_repository() override;
 
       /// Check the name of the organization
       bool has_organization() const;
@@ -199,10 +199,10 @@ namespace datatools {
       bool is_initialized() const;
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// Return the number of registries
       unsigned int get_number_of_registries() const;

--- a/source/bxdatatools/include/datatools/detail/ocd_utils.h
+++ b/source/bxdatatools/include/datatools/detail/ocd_utils.h
@@ -239,7 +239,7 @@ namespace datatools {
             _class_id_ = class_id_;
           }
         }
-        virtual ~system_factory_registrar() {
+        ~system_factory_registrar() override {
           DT_LOG_TRACE(_logging_, "Destruction of OCD system_factory_registrar for registered class '" << _class_id_ << "'...");
           ocd_registration & ocd_reg = ocd_registration::grab_system_registration();
           if (! _class_id_.empty() && ocd_reg.has_id(_class_id_)) {

--- a/source/bxdatatools/include/datatools/enriched_base.h
+++ b/source/bxdatatools/include/datatools/enriched_base.h
@@ -72,7 +72,7 @@ namespace datatools {
                   logger::priority lp_ = logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~enriched_base();
+    ~enriched_base() override;
 
     /// Check if the name is not empty
     bool has_name() const;

--- a/source/bxdatatools/include/datatools/event_id.h
+++ b/source/bxdatatools/include/datatools/event_id.h
@@ -89,7 +89,7 @@ namespace datatools {
     event_id(int r_, int e_);
 
     //! The destructor.
-    virtual ~event_id() = default;
+    ~event_id() override = default;
 
     //! Copy constructor
     event_id(const event_id &) = default;
@@ -104,7 +104,7 @@ namespace datatools {
     event_id & operator=(event_id &&) = default;    
 
     //! Invalidate the id.
-    virtual void clear();
+    void clear() override;
 
     //! Invalidate the id.
     void reset();
@@ -182,10 +182,10 @@ namespace datatools {
      *   @param indent_ the indentation string
      *   @param inherit_ the inheritance flag.
      */
-    virtual void tree_dump(std::ostream & out_ = std::cerr,
+    void tree_dump(std::ostream & out_ = std::cerr,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     void smart_print(std::ostream & out_,
                      const std::string & title_,

--- a/source/bxdatatools/include/datatools/factory.h
+++ b/source/bxdatatools/include/datatools/factory.h
@@ -75,7 +75,7 @@ namespace datatools {
     factory_register(const std::string & label_, unsigned int flags_ = 0x0);
 
     /// Destructor
-    virtual ~factory_register();
+    ~factory_register() override;
 
     //! Returns logging priority
     datatools::logger::priority get_logging_priority() const;
@@ -151,10 +151,10 @@ namespace datatools {
     void print(std::ostream & out_, const std::string & indent_ = "") const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string& title_ = "",
                            const std::string& indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   private:
 

--- a/source/bxdatatools/include/datatools/i_cloneable.h
+++ b/source/bxdatatools/include/datatools/i_cloneable.h
@@ -112,12 +112,12 @@ namespace datatools {
 
 #define DATATOOLS_CLONEABLE_DECLARATION(Copyable) \
   public:                                         \
-  virtual Copyable* clone(void) const;            \
+  virtual Copyable* clone(void) const override;            \
   /**/
 
 #define DATATOOLS_CLONEABLE_INLINE(Copyable)                  \
   public:                                                     \
-  virtual Copyable* clone(void) const {                       \
+  virtual Copyable* clone(void) const override {                       \
     return datatools::i_cloneable::clone_it<Copyable>(*this); \
   }
 /**/

--- a/source/bxdatatools/include/datatools/i_serializable.h
+++ b/source/bxdatatools/include/datatools/i_serializable.h
@@ -107,7 +107,7 @@ BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(has_bsts, backward_serial_tag_support, false)
 
 
 /** Intrusive macro invoked from the class declaration to
- *  declare serial tag support :
+ *  declare serial tag support for concrete classes of i_serializable:
  * Example:
  * \code
  * class Foo : public datatools::i_serializable
@@ -120,7 +120,24 @@ BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(has_bsts, backward_serial_tag_support, false)
   public:                                                 \
   static const std::string SERIAL_TAG;                    \
   static const std::string & serial_tag();                \
-  virtual const std::string& get_serial_tag() const;      \
+  virtual const std::string& get_serial_tag() const override;      \
+  /**/
+
+/** Intrusive macro invoked from the class declaration to
+ *  declare serial tag support for classes not inheriting from i_serializable:
+ * Example:
+ * \code
+ * class Foo
+ * {
+ *   DATATOOLS_SERIALIZATION_SERIAL_TAG_DECLARATION_NOINHERIT()
+ * };
+ * \endcode
+ */
+#define DATATOOLS_SERIALIZATION_SERIAL_TAG_DECLARATION_NOINHERIT()  \
+  public:                                                 \
+  static const std::string SERIAL_TAG;                    \
+  static const std::string & serial_tag();                \
+  const std::string& get_serial_tag() const;      \
   /**/
 
 
@@ -251,9 +268,8 @@ BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(has_bsts, backward_serial_tag_support, false)
                                                                         \
   /**/
 
-
 /** Intrusive macro invoked from the class declaration to activate
- *  basic serialization support for the class :
+ *  basic serialization support for the class inheriting from i_serializable :
  *
  * Example:
  * \code
@@ -268,6 +284,24 @@ BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(has_bsts, backward_serial_tag_support, false)
   DATATOOLS_SERIALIZATION_SERIAL_TAG_DECLARATION()  \
   BOOST_SERIALIZATION_BASIC_DECLARATION ()          \
   /**/
+
+/** Intrusive macro invoked from the class declaration to activate
+ *  basic serialization support for the class without inheriting from i_serializable:
+ *
+ * Example:
+ * \code
+ *   class Foo
+ *   {
+ *      DATATOOLS_SERIALIZATION_DECLARATION_NOINHERIT();
+ *   };
+ * \endcode
+ */
+#define DATATOOLS_SERIALIZATION_DECLARATION_NOINHERIT()       \
+  public:                                           \
+  DATATOOLS_SERIALIZATION_SERIAL_TAG_DECLARATION_NOINHERIT()  \
+  BOOST_SERIALIZATION_BASIC_DECLARATION ()          \
+  /**/
+
 
 /** Shortcut macro to generate the proper prototype of the
  * Boost serialization method :

--- a/source/bxdatatools/include/datatools/introspection/argument.h
+++ b/source/bxdatatools/include/datatools/introspection/argument.h
@@ -52,7 +52,7 @@ namespace datatools {
       argument();
 
       //! Destructor
-      ~argument();
+      ~argument() override;
 
       //! Check if the method of which the argument belong to the list of arguments is set
       bool has_method() const;
@@ -205,10 +205,10 @@ namespace datatools {
                             const std::string & prefix_ = "") const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     private:
 

--- a/source/bxdatatools/include/datatools/introspection/data_description.h
+++ b/source/bxdatatools/include/datatools/introspection/data_description.h
@@ -46,7 +46,7 @@ namespace datatools {
       data_description();
 
       //! Destructor
-      ~data_description();
+      ~data_description() override;
 
       //! Check if data type is defined
       bool has_type() const;
@@ -180,10 +180,10 @@ namespace datatools {
                             const std::string & prefix_ = "") const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       //! Build a scalar data
       void make_scalar(data_type, const std::string & info_ = "", const std::string & info2_ = "");

--- a/source/bxdatatools/include/datatools/introspection/method.h
+++ b/source/bxdatatools/include/datatools/introspection/method.h
@@ -51,7 +51,7 @@ namespace datatools {
       method();
 
       //! Destructor
-      virtual ~method();
+      ~method() override;
 
       //! Check if constness is set
       bool has_constness() const;
@@ -144,10 +144,10 @@ namespace datatools {
                             const std::string & prefix_ = "") const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       //! Make a setter method with one unique input scalar argument
       void make_scalar_setter(const std::string & arg_name_,

--- a/source/bxdatatools/include/datatools/introspection/unit_support.h
+++ b/source/bxdatatools/include/datatools/introspection/unit_support.h
@@ -74,7 +74,7 @@ namespace datatools {
       unit_info(unit_support_type, const std::string & unit_token_, const std::string & unit_token2_ = "");
 
       //! Destructor
-      virtual ~unit_info();
+      ~unit_info() override;
 
       //! Check validity
       bool is_valid() const;
@@ -166,10 +166,10 @@ namespace datatools {
                             const std::string & prefix_ = "") const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       //! Make the class "equality comparable" (needed by Boost/optional for some reason...)
       //! Do not understand why (see also the "data_description::has_unit_info()" method)

--- a/source/bxdatatools/include/datatools/io_factory.h
+++ b/source/bxdatatools/include/datatools/io_factory.h
@@ -190,7 +190,7 @@ namespace datatools {
                int mode_ = io_factory::MODE_DEFAULT);
 
     /// Destructor
-    virtual ~io_factory();
+    ~io_factory() override;
 
     bool eof() const;
 
@@ -351,10 +351,10 @@ namespace datatools {
       return iof_;
     }
 
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     void dump(std::ostream & out_) const;
 
@@ -461,7 +461,7 @@ namespace datatools {
     io_reader(const std::string & stream_name_,
               int mode_ = io_factory::MODE_DEFAULT);
 
-    virtual ~io_reader();
+    ~io_reader() override;
   };
 
 
@@ -480,7 +480,7 @@ namespace datatools {
     io_writer(const std::string & stream_name_,
               int mode_ = io_factory::MODE_DEFAULT);
 
-    virtual ~io_writer();
+    ~io_writer() override;
   };
 
   //----------------------------------------------------------------------

--- a/source/bxdatatools/include/datatools/kernel.h
+++ b/source/bxdatatools/include/datatools/kernel.h
@@ -153,7 +153,7 @@ namespace datatools {
     kernel(int argc_, char * argv_[], uint32_t flags = 0);
 
     /// Destruction with on-the-fly shutdown if needed
-    virtual ~kernel();
+    ~kernel() override;
 
     /// Initialization from command line arguments
     void initialize(int argc_, char * argv_[], uint32_t flags_ = 0);
@@ -311,7 +311,7 @@ namespace datatools {
     void tree_dump(std::ostream & out_ = std::clog,
                    const std::string & title_ = "",
                    const std::string & indent_ = "",
-                   bool inherit_ = false) const;
+                   bool inherit_ = false) const override;
 
     /// Registration of resource paths
     void register_resource_paths();

--- a/source/bxdatatools/include/datatools/library_info.h
+++ b/source/bxdatatools/include/datatools/library_info.h
@@ -105,7 +105,7 @@ namespace datatools {
     library_info();
 
     /// Destructor
-    virtual ~library_info();
+    ~library_info() override;
 
     /// Return the logging priority of the library info register
     logger::priority get_logging() const;
@@ -233,7 +233,7 @@ namespace datatools {
     void tree_dump(std::ostream & out_ = std::clog,
                    const std::string & title_ = "",
                    const std::string & indent_ = "",
-                   bool inherit_ = false) const;
+                   bool inherit_ = false) const override;
 
   private:
 

--- a/source/bxdatatools/include/datatools/library_query_service.h
+++ b/source/bxdatatools/include/datatools/library_query_service.h
@@ -40,23 +40,23 @@ namespace datatools {
     library_query_service();
 
     //! Destructor
-    virtual ~library_query_service();
+    ~library_query_service() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialize the service from a list of properties
-    virtual int initialize(const datatools::properties & config_,
-                           datatools::service_dict_type & services_);
+    int initialize(const datatools::properties & config_,
+                           datatools::service_dict_type & services_) override;
 
     //! Reset
-    virtual int reset();
+    int reset() override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Return a mutable reference to the embedded library info dictionary
     library_info & grab_libinfo();

--- a/source/bxdatatools/include/datatools/memory_streambuf.h
+++ b/source/bxdatatools/include/datatools/memory_streambuf.h
@@ -83,7 +83,7 @@ namespace datatools {
                          size_t increment_ = 1000,
                          size_t max_capacity_ = 0);
 
-    virtual ~vector_output_buffer();
+    ~vector_output_buffer() override;
 
     const std::vector<char>& buffer() const;
 
@@ -107,7 +107,7 @@ namespace datatools {
   public:
     void dump() const;
 
-    int overflow(int c_);
+    int overflow(int c_) override;
 
   private:
 

--- a/source/bxdatatools/include/datatools/multi_properties.h
+++ b/source/bxdatatools/include/datatools/multi_properties.h
@@ -125,7 +125,7 @@ namespace datatools {
             const std::string & meta_ = "");
 
       /// Destructor
-      virtual ~entry() = default;
+      ~entry() override = default;
 
       /// Copy constructor
       entry(const entry &) = default;
@@ -167,10 +167,10 @@ namespace datatools {
       /// Smart print
       ///
       /// \deprecated
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     private:
       std::string _key_;        //!< Primary key of the section
@@ -215,7 +215,7 @@ namespace datatools {
                      const std::string & description_);
 
     /// Destructor
-    virtual ~multi_properties() = default;
+    ~multi_properties() override = default;
 
     /// Copy constructor
     multi_properties(const multi_properties &);
@@ -272,7 +272,7 @@ namespace datatools {
     void reset();
 
     /// Clear the dictionary of sections
-    virtual void clear();
+    void clear() override;
 
     /// Return the const reference to the collection of entries
     const entries_col_type & entries() const;
@@ -487,10 +487,10 @@ namespace datatools {
     /// Smart print
     ///
     /// \deprecated
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// \brief Reader/writer class for multi_properties objects
     class config

--- a/source/bxdatatools/include/datatools/properties.h
+++ b/source/bxdatatools/include/datatools/properties.h
@@ -841,7 +841,7 @@ namespace datatools {
     explicit properties(const std::string & desc_);
 
     /// Destructor
-    virtual ~properties() = default;
+    ~properties() override = default;
 
     /// Copy constructor
     properties(const properties &) = default;
@@ -1083,7 +1083,7 @@ namespace datatools {
     void clean(const std::string & prop_key_);
 
     //! Reset method (from the datatools::i_clear interface).
-    virtual void clear();
+    void clear() override;
 
     //! Reset method
     void reset();
@@ -1429,10 +1429,10 @@ namespace datatools {
     void dump(std::ostream & out_ = std::clog) const;
 
     //! \deprecated Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Smart print
     void print_tree(std::ostream & out_ = std::clog,

--- a/source/bxdatatools/include/datatools/service_manager.h
+++ b/source/bxdatatools/include/datatools/service_manager.h
@@ -95,7 +95,7 @@ namespace datatools {
                     uint32_t flag_ = BLANK);
 
     //! Destructor
-    virtual ~service_manager();
+    ~service_manager() override;
 
     //! Set the name of the service
     void set_name(const std::string& name_);
@@ -252,10 +252,10 @@ namespace datatools {
                        const std::string& indent_ = "") const;
 
     //! Smart print
-    virtual void tree_dump(std::ostream& out_         = std::clog,
+    void tree_dump(std::ostream& out_         = std::clog,
                            const std::string& title_  = "",
                            const std::string& indent_ = "",
-                           bool inherit_              = false) const;
+                           bool inherit_              = false) const override;
 
     //! Set the logging priority threshold
     void set_logging_priority(datatools::logger::priority);

--- a/source/bxdatatools/include/datatools/service_tools.h
+++ b/source/bxdatatools/include/datatools/service_tools.h
@@ -104,7 +104,7 @@ namespace datatools {
     service_entry(const std::string & name_, service_manager & mgr_);
 
     /// Destructor
-    ~service_entry();
+    ~service_entry() override;
 
     /// Return the service name
     const std::string & get_service_name() const;
@@ -149,10 +149,10 @@ namespace datatools {
     bool has_master(const std::string& name_) const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream& out_ = std::clog,
+    void tree_dump(std::ostream& out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Return a handle to the non mutable service
     const service_handle_type & get_service_handle() const;

--- a/source/bxdatatools/include/datatools/things.h
+++ b/source/bxdatatools/include/datatools/things.h
@@ -71,9 +71,9 @@ namespace datatools {
 
     explicit bad_things_cast (const std::string & msg_);
 
-    virtual ~bad_things_cast() throw();
+    ~bad_things_cast() throw() override;
 
-    virtual const char* what() const throw();
+    const char* what() const throw() override;
 
   private:
 
@@ -100,7 +100,7 @@ namespace datatools {
 
       entry_type();
 
-      virtual ~entry_type();
+      ~entry_type() override;
 
       bool is_not_const() const;
 
@@ -114,10 +114,10 @@ namespace datatools {
 
       bool has_description() const;
 
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     public:
 
@@ -147,7 +147,7 @@ namespace datatools {
     things(const std::string & name_, const std::string & description_ = "");
 
     // Destructor
-    virtual ~things();
+    ~things() override;
 
     /// Return the name of the container
     const std::string & get_name() const;
@@ -186,7 +186,7 @@ namespace datatools {
     void reset();
 
     /// Clear the container
-    virtual void clear();
+    void clear() override;
 
     /// Return the number of objects stored in the container
     unsigned int size() const;
@@ -291,10 +291,10 @@ namespace datatools {
     std::string get_entry_introspection_id(const std::string & name_) const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Basic print
     void dump(std::ostream & out_ = std::clog) const;

--- a/source/bxdatatools/include/datatools/time_tools.h
+++ b/source/bxdatatools/include/datatools/time_tools.h
@@ -26,7 +26,7 @@ namespace datatools {
     computing_time();
 
     /// Destructor
-    virtual ~computing_time();
+    ~computing_time() override;
 
     bool is_stopped() const;
 
@@ -60,10 +60,10 @@ namespace datatools {
 
     void reset();
 
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
          const std::string & title_ = "",
          const std::string & indent_ = "",
-         bool inherit_ = false) const;
+         bool inherit_ = false) const override;
 
     static bool g_timeval_subtract(const timeval & stop_,
            const timeval & start_,

--- a/source/bxdatatools/include/datatools/ui/base_command.h
+++ b/source/bxdatatools/include/datatools/ui/base_command.h
@@ -56,7 +56,7 @@ namespace datatools {
       typedef boost::program_options::variables_map                  vmap_type;
 
       //! Check if a name is valid
-      virtual bool is_name_valid(const std::string & candidate_name_) const;
+      bool is_name_valid(const std::string & candidate_name_) const override;
 
       //! Default constructor
       base_command();
@@ -67,7 +67,7 @@ namespace datatools {
                    const version_id & vid_ = version_id::invalid());
 
       //! Destructor
-      virtual ~base_command();
+      ~base_command() override;
 
       //! Check if some generic options are described
       bool has_generic_opts() const;
@@ -154,10 +154,10 @@ namespace datatools {
       void print_version(std::ostream & out_, uint32_t flags_ = 0) const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     protected:
 

--- a/source/bxdatatools/include/datatools/ui/base_command_interface.h
+++ b/source/bxdatatools/include/datatools/ui/base_command_interface.h
@@ -65,7 +65,7 @@ namespace datatools {
                              const version_id & vid_ = version_id::invalid());
 
       //! Destructor
-      virtual ~base_command_interface();
+      ~base_command_interface() override;
 
       //! Check if the version is set
       bool has_version() const;
@@ -129,10 +129,10 @@ namespace datatools {
       bool is_disabled() const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       //! Main command call operator
       int operator()(const std::vector<std::string> & argv_,

--- a/source/bxdatatools/include/datatools/ui/basic_shell.h
+++ b/source/bxdatatools/include/datatools/ui/basic_shell.h
@@ -86,7 +86,7 @@ namespace datatools {
       basic_shell(const std::string & name_ = "");
 
       //! Destructor
-      virtual ~basic_shell();
+      ~basic_shell() override;
 
       //! Return the logging priority threshold
       datatools::logger::priority get_logging() const;
@@ -321,8 +321,8 @@ namespace datatools {
       //!   "ihs"      : false
       //! }
       //! \endcode
-      virtual void print_tree(std::ostream & out_ = std::clog,
-                              const boost::property_tree::ptree & options_ = datatools::i_tree_dumpable::empty_options()) const;
+      void print_tree(std::ostream & out_ = std::clog,
+                              const boost::property_tree::ptree & options_ = datatools::i_tree_dumpable::empty_options()) const override;
 
     protected:
 

--- a/source/bxdatatools/include/datatools/ui/ihs.h
+++ b/source/bxdatatools/include/datatools/ui/ihs.h
@@ -97,7 +97,7 @@ namespace datatools {
         node(node_type type_, const std::string & full_path_);
 
         //! Destructor
-        virtual ~node();
+        ~node() override;
 
         //! Reset the node
         void reset();
@@ -211,10 +211,10 @@ namespace datatools {
         void set_ihs(ihs &);
 
         //! Smart print
-        virtual void tree_dump(std::ostream & out_ = std::clog,
+        void tree_dump(std::ostream & out_ = std::clog,
                                const std::string & title_  = "",
                                const std::string & indent_ = "",
-                               bool inherit = false) const;
+                               bool inherit = false) const override;
 
         //! Set trait flag
         void set_trait(const std::string & trait_label_, const bool set_ = true);
@@ -249,7 +249,7 @@ namespace datatools {
       ihs(const std::string & scheme_ = "");
 
       //! Destructor
-      virtual ~ihs();
+      ~ihs() override;
 
       // //! Return the root path
       // const std::string & get_root_path() const;
@@ -354,10 +354,10 @@ namespace datatools {
       std::string canonical_path(const std::string & path_) const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit = false) const;
+                             bool inherit = false) const override;
 
       //! Build a set of paths
       void build_path(std::set<std::string> & paths_, const uint32_t flags_ = 0) const;

--- a/source/bxdatatools/include/datatools/ui/shell_cd_command.h
+++ b/source/bxdatatools/include/datatools/ui/shell_cd_command.h
@@ -35,10 +35,10 @@ namespace datatools {
       : public target_command<basic_shell>
     {
       shell_cd_command(basic_shell &);
-      virtual ~shell_cd_command();
+      ~shell_cd_command() override;
     protected:
-      virtual void _init(const datatools::properties & config_);
-      virtual void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0);
+      void _init(const datatools::properties & config_) override;
+      void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0) override;
     };
 
   } // namespace ui

--- a/source/bxdatatools/include/datatools/ui/shell_command_interface.h
+++ b/source/bxdatatools/include/datatools/ui/shell_command_interface.h
@@ -56,17 +56,17 @@ namespace datatools {
                               const datatools::version_id & vid_ = datatools::version_id::invalid());
 
       //! Destructor
-      virtual ~shell_command_interface();
+      ~shell_command_interface() override;
 
       //! Check initialization status
-      virtual bool is_initialized() const;
+      bool is_initialized() const override;
 
       //! Initialization
-      virtual void initialize(const datatools::properties & config_,
-                              const datatools::service_manager & services_);
+      void initialize(const datatools::properties & config_,
+                              const datatools::service_manager & services_) override;
 
       //! Reset
-      virtual void reset();
+      void reset() override;
 
       //! Check if the load command is inhibited
       bool is_inhibit_load() const;

--- a/source/bxdatatools/include/datatools/ui/shell_exit_command.h
+++ b/source/bxdatatools/include/datatools/ui/shell_exit_command.h
@@ -35,9 +35,9 @@ namespace datatools {
       : public target_command<basic_shell>
     {
       shell_exit_command(basic_shell &);
-      virtual ~shell_exit_command();
+      ~shell_exit_command() override;
     protected:
-      virtual void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0);
+      void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0) override;
     };
 
   } // namespace ui

--- a/source/bxdatatools/include/datatools/ui/shell_help_command.h
+++ b/source/bxdatatools/include/datatools/ui/shell_help_command.h
@@ -35,10 +35,10 @@ namespace datatools {
       : public const_target_command<basic_shell>
     {
       shell_help_command(const basic_shell &);
-      virtual ~shell_help_command();
+      ~shell_help_command() override;
     protected:
-      virtual void _init(const datatools::properties & config_);
-      virtual void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0);
+      void _init(const datatools::properties & config_) override;
+      void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0) override;
     };
 
   } // namespace ui

--- a/source/bxdatatools/include/datatools/ui/shell_load_command.h
+++ b/source/bxdatatools/include/datatools/ui/shell_load_command.h
@@ -35,10 +35,10 @@ namespace datatools {
       : public target_command<basic_shell>
     {
       shell_load_command(basic_shell &);
-      virtual ~shell_load_command();
+      ~shell_load_command() override;
     protected:
-      virtual void _init(const datatools::properties & config_);
-      virtual void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0);
+      void _init(const datatools::properties & config_) override;
+      void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0) override;
     };
 
   } // namespace ui

--- a/source/bxdatatools/include/datatools/ui/shell_ls_command.h
+++ b/source/bxdatatools/include/datatools/ui/shell_ls_command.h
@@ -35,10 +35,10 @@ namespace datatools {
       : public const_target_command<basic_shell>
     {
       shell_ls_command(const basic_shell &);
-      virtual ~shell_ls_command();
+      ~shell_ls_command() override;
     protected:
-      virtual void _init(const datatools::properties & config_);
-      virtual void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0);
+      void _init(const datatools::properties & config_) override;
+      void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0) override;
     };
 
   } // namespace ui

--- a/source/bxdatatools/include/datatools/ui/shell_man_command.h
+++ b/source/bxdatatools/include/datatools/ui/shell_man_command.h
@@ -35,10 +35,10 @@ namespace datatools {
       : public const_target_command<basic_shell>
     {
       shell_man_command(const basic_shell &);
-      virtual ~shell_man_command();
+      ~shell_man_command() override;
     protected:
-      virtual void _init(const datatools::properties & config_);
-      virtual void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0);
+      void _init(const datatools::properties & config_) override;
+      void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0) override;
     };
 
   } // namespace ui

--- a/source/bxdatatools/include/datatools/ui/shell_pwd_command.h
+++ b/source/bxdatatools/include/datatools/ui/shell_pwd_command.h
@@ -35,9 +35,9 @@ namespace datatools {
       : public const_target_command<basic_shell>
     {
       shell_pwd_command(const basic_shell &);
-      virtual ~shell_pwd_command();
+      ~shell_pwd_command() override;
     protected:
-      virtual void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0);
+      void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0) override;
     };
 
   } // namespace ui

--- a/source/bxdatatools/include/datatools/ui/shell_tree_command.h
+++ b/source/bxdatatools/include/datatools/ui/shell_tree_command.h
@@ -35,10 +35,10 @@ namespace datatools {
       : public const_target_command<basic_shell>
     {
       shell_tree_command(const basic_shell &);
-      virtual ~shell_tree_command();
+      ~shell_tree_command() override;
     protected:
-      virtual void _init(const datatools::properties & config_);
-      virtual void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0);
+      void _init(const datatools::properties & config_) override;
+      void _run(datatools::command::returned_info & cri_, uint32_t flags_ = 0) override;
 
       //! Recursive tree print
       void _tree_print_children(std::ostream & out_,

--- a/source/bxdatatools/include/datatools/ui/target_command.h
+++ b/source/bxdatatools/include/datatools/ui/target_command.h
@@ -61,13 +61,13 @@ namespace datatools {
       }
 
       //! Destructor
-      virtual ~target_command()
+      ~target_command() override
       {
         return;
       }
 
       //! Check validity
-      virtual bool is_valid() const
+      bool is_valid() const override
       {
         return base_command::is_valid() && has_target();
       }
@@ -90,10 +90,10 @@ namespace datatools {
       }
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const
+                             bool inherit_ = false) const override
       {
         this->base_command::tree_dump(out_, title_, indent_, true);
 
@@ -152,13 +152,13 @@ namespace datatools {
       }
 
       //! Destructor
-      virtual ~const_target_command()
+      ~const_target_command() override
       {
         return;
       }
 
       //! Check validity
-      virtual bool is_valid() const
+      bool is_valid() const override
       {
         return base_command::is_valid() && has_target();
       }
@@ -175,10 +175,10 @@ namespace datatools {
       }
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const
+                             bool inherit_ = false) const override
       {
         this->base_command::tree_dump(out_, title_, indent_, true);
 

--- a/source/bxdatatools/include/datatools/ui/target_command_interface.h
+++ b/source/bxdatatools/include/datatools/ui/target_command_interface.h
@@ -70,7 +70,7 @@ namespace datatools {
       }
 
       //! Destructor
-      virtual ~target_command_interface()
+      ~target_command_interface() override
       {
         return;
       }
@@ -103,10 +103,10 @@ namespace datatools {
       }
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const
+                             bool inherit_ = false) const override
       {
         this->base_command_interface::tree_dump(out_, title_, indent_, true);
 
@@ -179,7 +179,7 @@ namespace datatools {
       }
 
       //! Destructor
-      virtual ~const_target_command_interface()
+      ~const_target_command_interface() override
       {
         return;
       }
@@ -206,10 +206,10 @@ namespace datatools {
       }
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const
+                             bool inherit_ = false) const override
       {
         this->base_command_interface::tree_dump(out_, title_, indent_, true);
 

--- a/source/bxdatatools/include/datatools/units.h
+++ b/source/bxdatatools/include/datatools/units.h
@@ -396,7 +396,7 @@ namespace datatools {
            bool SI_main_ = false);
 
       //! Destructor
-      virtual ~unit();
+      ~unit() override;
 
       //! Check validity
       bool is_valid() const;
@@ -480,10 +480,10 @@ namespace datatools {
       // std::ostream & operator()(std::ostream & out_, double x_) const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     protected:
 
@@ -544,7 +544,7 @@ namespace datatools {
                      const std::string & default_unit_symbol_);
 
       //! Destructor
-      virtual ~unit_dimension();
+      ~unit_dimension() override;
 
       //! Check validity
       bool is_valid() const;
@@ -602,10 +602,10 @@ namespace datatools {
       bool match_dimensional_powers(const unit_dimension & ud_) const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     protected:
 
@@ -645,7 +645,7 @@ namespace datatools {
       registry(uint32_t flags_ = 0);
 
       //! Destructor
-      ~registry();
+      ~registry() override;
 
       //! Registration of an unit
       void registration(const unit & unit_, bool default_in_dimension_ = false);
@@ -697,10 +697,10 @@ namespace datatools {
       void register_standard_units();
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     protected:
 

--- a/source/bxdatatools/include/datatools/urn.h
+++ b/source/bxdatatools/include/datatools/urn.h
@@ -70,7 +70,7 @@ namespace datatools {
     urn(const std::vector<std::string> & segments_);
 
     /// Destructor
-    virtual ~urn();
+    ~urn() override;
 
     /// Check validity
     bool is_valid() const;

--- a/source/bxdatatools/include/datatools/urn_db_service.h
+++ b/source/bxdatatools/include/datatools/urn_db_service.h
@@ -202,7 +202,7 @@ namespace datatools {
     urn_db_service();
 
     /// Destructor
-    virtual ~urn_db_service();
+    ~urn_db_service() override;
 
     //! Check if mounted URN are allowed
     bool is_allow_mounted() const;
@@ -256,20 +256,20 @@ namespace datatools {
     std::set<std::string> get_dependees() const;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialize the service from a list of properties
-    virtual int initialize(const datatools::properties & config_,
-                           datatools::service_dict_type & services_);
+    int initialize(const datatools::properties & config_,
+                           datatools::service_dict_type & services_) override;
 
     //! Reset
-    virtual int reset();
+    int reset() override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream& out = std::clog,
+    void tree_dump(std::ostream& out = std::clog,
                            const std::string & title = "",
                            const std::string & indent = "",
-                           bool inherit = false) const;
+                           bool inherit = false) const override;
 
     //! Load an URN info definition file
     void load(const std::string & filename_);

--- a/source/bxdatatools/include/datatools/urn_info.h
+++ b/source/bxdatatools/include/datatools/urn_info.h
@@ -118,7 +118,7 @@ namespace datatools {
              const std::string & description_ = "");
 
     /// Destructor
-    virtual ~urn_info();
+    ~urn_info() override;
 
     /// Check validity
     bool is_valid() const;
@@ -228,10 +228,10 @@ namespace datatools {
     std::vector<std::string> get_topics() const;
 
     /// Main interface method for smart dump
-    virtual void tree_dump(std::ostream& out = std::clog,
+    void tree_dump(std::ostream& out = std::clog,
                            const std::string& title  = "",
                            const std::string& indent = "",
-                           bool inherit = false) const;
+                           bool inherit = false) const override;
 
     /// Basic comparison with respect to the URN name
     bool operator<(const urn_info & other_) const;

--- a/source/bxdatatools/include/datatools/urn_query_service.h
+++ b/source/bxdatatools/include/datatools/urn_query_service.h
@@ -61,23 +61,23 @@ namespace datatools {
     urn_query_service();
 
     /// Destructor
-    virtual ~urn_query_service();
+    ~urn_query_service() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialize the service from a list of properties
-    virtual int initialize(const datatools::properties & config_,
-                           datatools::service_dict_type & services_);
+    int initialize(const datatools::properties & config_,
+                           datatools::service_dict_type & services_) override;
 
     //! Reset
-    virtual int reset();
+    int reset() override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out = std::clog,
+    void tree_dump(std::ostream & out = std::clog,
                            const std::string & title = "",
                            const std::string & indent = "",
-                           bool inherit = false) const;
+                           bool inherit = false) const override;
 
     /// Check if an URN information is defined
     bool check_urn_info(const std::string & urn_,

--- a/source/bxdatatools/include/datatools/urn_to_path.h
+++ b/source/bxdatatools/include/datatools/urn_to_path.h
@@ -80,7 +80,7 @@ namespace datatools {
                 const std::vector<std::string> & paths_);
 
     /// Destructor
-    virtual ~urn_to_path();
+    ~urn_to_path() override;
 
     /// Check validity
     bool is_valid() const;
@@ -149,10 +149,10 @@ namespace datatools {
     void reset_mime();
 
     /// Main interface method for smart dump
-    virtual void tree_dump (std::ostream & out_ = std::clog,
+    void tree_dump (std::ostream & out_ = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_ = false) const;
+                            bool inherit_ = false) const override;
 
   private:
 

--- a/source/bxdatatools/include/datatools/urn_to_path_resolver_service.h
+++ b/source/bxdatatools/include/datatools/urn_to_path_resolver_service.h
@@ -83,7 +83,7 @@ namespace datatools {
     urn_to_path_resolver_service();
 
     //! Destructor
-    virtual ~urn_to_path_resolver_service();
+    ~urn_to_path_resolver_service() override;
 
     //! Add a known catagory
     void add_known_category(const std::string & cat_);
@@ -107,20 +107,20 @@ namespace datatools {
     void add_map(const std::string &);
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialize the service from a list of properties
-    virtual int initialize(const datatools::properties & config_,
-                           datatools::service_dict_type & services_);
+    int initialize(const datatools::properties & config_,
+                           datatools::service_dict_type & services_) override;
 
     //! Reset
-    virtual int reset();
+    int reset() override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream& out = std::clog,
+    void tree_dump(std::ostream& out = std::clog,
                            const std::string & title = "",
                            const std::string & indent = "",
-                           bool inherit = false) const;
+                           bool inherit = false) const override;
 
     //! Load a URN/path map file
     void load_map(const std::string & map_filename_);

--- a/source/bxdatatools/src/dependency_graph.cc
+++ b/source/bxdatatools/src/dependency_graph.cc
@@ -349,7 +349,7 @@ namespace datatools {
   class graph_property_writer
   {
   public:
-    graph_property_writer(const dependency_graph::graph_t & g_) : _g_(g_) {}
+    graph_property_writer(const dependency_graph::graph_t & /*g_*/) /*: _g_(g_)*/ {}
     void operator()(std::ostream & out_) const
     {
       out_ << "graph [bgcolor=\"white\" color=\"black\"]" << std::endl;
@@ -357,7 +357,7 @@ namespace datatools {
       out_ << "edge [style=\"dashed\" color=\"black\"]" << std::endl;
     }
   private:
-    const dependency_graph::graph_t & _g_;
+    // const dependency_graph::graph_t & _g_;
   };
 
   void dependency_graph::export_graphviz(std::ostream & out_, const uint32_t flags_) const

--- a/source/bxdatatools/src/properties.cc
+++ b/source/bxdatatools/src/properties.cc
@@ -102,7 +102,6 @@ namespace {
     static const char METACOMMENT_CHAR = '@'; ///< Comment character
     static const char SPACE_CHAR   = ' '; ///< Space character
     static const char CONTINUATION_CHAR = '\\'; ///< Continuation character
-    static const char APPEND_CHAR = '+'; ///< Append character
 
     static const std::string & boolean_label()
     {
@@ -135,7 +134,7 @@ namespace {
 namespace datatools {
 
   DATATOOLS_SERIALIZATION_IMPLEMENTATION_ADVANCED(properties,"datatools::properties")
-  
+
   //----------------------------------------------------------------------
   // properties::data class implementation
   //
@@ -1114,7 +1113,7 @@ namespace datatools {
                 std::logic_error,
                 "Empty key prefix argument !");
     size_t n = prefix_.size();
-    for (const auto& p : _props_) { 
+    for (const auto& p : _props_) {
       if (p.first.size() < n) continue;
       if (p.first.substr(0, n) == prefix_) {
         some_keys.push_back(p.first);
@@ -2438,7 +2437,7 @@ namespace datatools {
   {
     std::vector<std::string> vvalues;
     this->fetch(a_key, vvalues);
-    
+
     for (const auto& value : vvalues) {
       DT_THROW_IF(values.count(value) != 0 && ! allow_duplication_,
                   std::logic_error,
@@ -2520,7 +2519,7 @@ namespace datatools {
     data_ptr->to_string(oss);
     return oss.str();
   }
-  
+
   void properties::print_tree(std::ostream & out_,
                               const boost::property_tree::ptree & options_) const
   {
@@ -2596,11 +2595,11 @@ namespace datatools {
         a_data.tree_dump(outs, "", indent_oss.str());
       }
     }
-    
+
     out_ << outs.str();
     return;
   }
-  
+
   void properties::tree_dump(std::ostream & out_,
                              const std::string & title_,
                              const std::string & indent_,
@@ -3039,7 +3038,7 @@ namespace datatools {
     return;
   }
 
- 
+
   void properties::config::_init_defaults_()
   {
     _logging_ = datatools::logger::PRIO_FATAL;
@@ -3717,11 +3716,11 @@ namespace datatools {
                                     _current_line_number_,
                                     "Enforced break while parsing of a property has started!");
         }
-        
+
         // Manage included files:
         if (paths_to_be_included.size()) {
           DT_LOG_DEBUG(_logging_, "Before inclusion : ");
-          props_.print_tree(std::cerr);                    
+          props_.print_tree(std::cerr);
           // Trigger the inclusion of external file:
           for (const std::string & inc_path : paths_to_be_included) {
             DT_LOG_DEBUG(_logging_, "About to include file with path '" << inc_path << "'");
@@ -3740,11 +3739,11 @@ namespace datatools {
             if (datatools::logger::is_debug(_logging_)) {
               inc_conf.print_tree(std::cerr);
             }
-            props_.merge_with(inc_conf, include_file_allow_override);                    
+            props_.merge_with(inc_conf, include_file_allow_override);
           }
           paths_to_be_included.clear();
         }
-      
+
         // Parse line:
         // if (!skip_line && parsing ) {
         if (!skip_line) {
@@ -3765,7 +3764,7 @@ namespace datatools {
           if (flag_pos > 0) {
             if (line_parsing.substr(flag_pos - 1, 2) == "+=") {
               array_append = true;
-            } 
+            }
           }
           // Parse property desc:
           std::string property_desc_str = line_parsing.substr(0, flag_pos - (array_append ? 1 : 0));
@@ -3894,7 +3893,7 @@ namespace datatools {
                                         "Key override mode is not allowed for property with key '"
                                         << prop_key
                                         << "' at line '"
-                                        << line << "' !");            
+                                        << line << "' !");
               DT_PROP_CFG_READ_THROW_IF(! props_.is_vector(prop_key),
                                         std::logic_error,
                                         _current_filename_,
@@ -3914,7 +3913,7 @@ namespace datatools {
                                         "Invalid array index [" << std::to_string(array_override_index) << "] for key override mode for array property with key '"
                                         << prop_key
                                         << "' at line '"
-                                        << line << "' !");      
+                                        << line << "' !");
             }
             DT_PROP_CFG_READ_THROW_IF(array_append and scalar,
                                       std::logic_error,
@@ -3925,7 +3924,7 @@ namespace datatools {
                                       "Append mode is only supported for array property with key '"
                                       << prop_key
                                       << "' at line '"
-                                      << line << "' !");            
+                                      << line << "' !");
             std::istringstream type_ss(type_str2);
             std::string type_token;
             type_ss >> std::ws >> type_token >> std::ws;
@@ -3963,7 +3962,7 @@ namespace datatools {
                                       "Type mismatch '" << type_token << "' vs '" << props_.get_type_label(prop_key) << "' for array item override mode for key '"
                                       << prop_key
                                       << "' at line '"
-                                      << line << "' !");            
+                                      << line << "' !");
             if (! scalar && ! type_str3.empty()) {
               std::istringstream iss3(type_str3);
               std::string dummy;
@@ -3973,7 +3972,7 @@ namespace datatools {
                 type_ss.str(type_str3);
               }
             }
-            
+
             bool with_explicit_path = false;
             if (type == properties::data::TYPE_STRING_SYMBOL) {
               std::string token;
@@ -4090,7 +4089,7 @@ namespace datatools {
                                             << line << "' !");
                 }
               } // Token not emtpy
-  
+
               if (! enable_real_with_unit) {
                 DT_PROP_CFG_READ_THROW_IF(! requested_unit_label.empty()
                                           || ! requested_unit_symbol.empty(),
@@ -4118,7 +4117,7 @@ namespace datatools {
                                         << "' for key '"
                                         << prop_key << "' at line '" << line << "' !");
             }
-            
+
             DT_LOG_TRACE(logging, "type='"<< type << "'");
             DT_LOG_TRACE(logging, "locked='" << locked << "'");
             DT_LOG_TRACE(logging, "vsize='" << vsize << "'");
@@ -4657,7 +4656,7 @@ namespace datatools {
                                                 _section_start_line_number_,
                                                 _current_line_number_,
                                                 "Original property with key '" << prop_key << "' is not a boolean vector property!");
-                                  
+
                       data::vbool v_booleans_appended;
                       props_.fetch(prop_key, v_booleans_appended);
                       for (auto val : v_booleans) {
@@ -4673,7 +4672,7 @@ namespace datatools {
                                                 _section_start_line_number_,
                                                 _current_line_number_,
                                                 "Original property with key '" << prop_key << "' is not an integer vector property!");
-                                  
+
                       data::vint v_integers_appended;
                       props_.fetch(prop_key, v_integers_appended);
                       for (auto val : v_integers) {
@@ -4720,7 +4719,7 @@ namespace datatools {
                                                 _section_name_,
                                                 _section_start_line_number_,
                                                 _current_line_number_,
-                                                "Original property with key '" << prop_key << "' is not a string vector property!");                                  
+                                                "Original property with key '" << prop_key << "' is not a string vector property!");
                       DT_PROP_CFG_READ_THROW_IF(with_explicit_path != props_.is_explicit_path(prop_key),
                                                 std::logic_error,
                                                 _current_filename_,
@@ -4734,7 +4733,7 @@ namespace datatools {
                         v_strings_appended.push_back(val);
                       }
                       props_.update(prop_key, v_strings_appended);
-                    }                  
+                    }
                   }
                 }
                 prop_description.clear();
@@ -4746,7 +4745,7 @@ namespace datatools {
             }
             variant_only_reverse = false;
           }
-        } // !skip_line 
+        } // !skip_line
       } // if (! line_goon)
     } // while (*_in)
     DT_PROP_CFG_READ_THROW_IF(variant_if_blocks.size() > 0,
@@ -4819,7 +4818,7 @@ namespace datatools {
     }
     return;
   }
-  
+
   // static
   const properties & empty_config()
   {
@@ -4835,7 +4834,7 @@ namespace datatools {
       const data & a_data = p.second;
 
       std::ostringstream valoss;
-      
+
       if (a_data.is_vector()) valoss << '(';
 
       for (int i = 0; i < (int)a_data.get_size(); ++i) {

--- a/source/bxdatatools/testing/dummy_service.h
+++ b/source/bxdatatools/testing/dummy_service.h
@@ -52,26 +52,26 @@ namespace datatools {
     void set_label(const std::string & a_label);
 
     /// Check initialization
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Initialize
-    virtual int initialize(const datatools::properties & a_config,
-                           service_dict_type & a_service_dict);
+    int initialize(const datatools::properties & a_config,
+                   service_dict_type & a_service_dict) override;
 
     /// Reset
-    virtual int reset();
+    int reset() override;
 
     /// Default constructor
     dummy_service();
 
     /// Destructor
-    virtual ~dummy_service();
+    ~dummy_service() override;
 
     /// Smart print:
     virtual void tree_dump(std::ostream & a_out         = std::clog,
                            const std::string & a_title  = "",
                            const std::string & a_indent = "",
-                           bool a_inherit          = false) const;
+                           bool a_inherit          = false) const override;
 
   private:
 

--- a/source/bxdatatools/testing/test_cloneable_2.cxx
+++ b/source/bxdatatools/testing/test_cloneable_2.cxx
@@ -36,7 +36,7 @@ public:
   int    id_;
 public:
   static const string  SERIAL_TAG;
-  const string & get_serial_tag () const
+  const string & get_serial_tag () const override
   {
     return SERIAL_TAG;
   }

--- a/source/bxdatatools/testing/test_service_manager.cxx
+++ b/source/bxdatatools/testing/test_service_manager.cxx
@@ -49,7 +49,7 @@ public:
   test_service();
 
   /// Destructor
-  virtual ~test_service();
+  ~test_service() override;
 
   /// Set the label
   void set_label(const std::string & a_label);
@@ -58,23 +58,23 @@ public:
   const std::string & get_label() const;
 
   /// Check initialization status
-  virtual bool is_initialized() const;
+  bool is_initialized() const override;
 
   /// Initialize the service
-  virtual int initialize(const datatools::properties& /* config_ */,
-                         datatools::service_dict_type& /* service_map_ */);
+  int initialize(const datatools::properties& /* config_ */,
+                 datatools::service_dict_type& /* service_map_ */) override;
 
   /// Reset the service
-  virtual int reset();
+  int reset() override;
 
   /// Use the service
   void use_me_after_initialization();
 
   /// Smart print
-  virtual void tree_dump(std::ostream& out = std::clog,
-                         const std::string & title = "",
-                         const std::string & indent = "",
-                         bool inherit = false) const;
+  void tree_dump(std::ostream& out = std::clog,
+                 const std::string & title = "",
+                 const std::string & indent = "",
+                 bool inherit = false) const override;
 
 private:
 

--- a/source/bxdatatools/testing/test_urn_info.cxx
+++ b/source/bxdatatools/testing/test_urn_info.cxx
@@ -167,7 +167,7 @@ void test_urn_info_0()
   if (debug) std::cerr << std::endl;
   urns[uiSnSimu.get_urn()] = uiSnSimu;
 
-  for (const auto ui : urns) {
+  for (const auto& ui : urns) {
     ui.second.tree_dump(std::clog, "URN info: " + ui.second.get_urn(), "[info] ");
     std::clog << std::endl;
   }
@@ -182,7 +182,7 @@ void test_urn_info_0()
     datatools::data_reader r("urn_info_dict.xml");
     r.load("std::map<std::string,datatools::urn_info>", urns);
   }
-  for (const auto ui : urns) {
+  for (const auto& ui : urns) {
     ui.second.tree_dump(std::clog, "Loaded URN info: " + ui.second.get_urn(), "[info] ");
     std::clog << std::endl;
   }

--- a/source/bxdpp/include/dpp/base_module.h
+++ b/source/bxdpp/include/dpp/base_module.h
@@ -95,7 +95,7 @@ namespace dpp {
     base_module(datatools::logger::priority p_ = datatools::logger::PRIO_FATAL);
 
     /// Destructor :
-    virtual ~base_module();
+    ~base_module() override;
 
     /// Check the module name
     bool has_name() const;
@@ -170,10 +170,10 @@ namespace dpp {
     virtual void reset() = 0;
 
     /// Smart print
-    virtual void tree_dump(std::ostream &      out_ = std::clog,
+    void tree_dump(std::ostream &      out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool                inherit_ = false) const;
+                           bool                inherit_ = false) const override;
 
     /// Default print
     void print(std::ostream & out_ = std::clog) const;

--- a/source/bxdpp/include/dpp/chain_module.h
+++ b/source/bxdpp/include/dpp/chain_module.h
@@ -66,24 +66,24 @@ namespace dpp {
     chain_module(datatools::logger::priority = datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~chain_module();
+    ~chain_module() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties & /* config_ */,
+    void initialize(const ::datatools::properties & /* config_ */,
                             datatools::service_manager & /* service_mgr_ */,
-                            dpp::module_handle_dict_type & /* modules_map_ */);
+                            dpp::module_handle_dict_type & /* modules_map_ */) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Data record processing
-    virtual process_status process(::datatools::things & /* data_ */);
+    process_status process(::datatools::things & /* data_ */) override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream      & out_    = std::clog,
+    void tree_dump(std::ostream      & out_    = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   protected:
 

--- a/source/bxdpp/include/dpp/context_service.h
+++ b/source/bxdpp/include/dpp/context_service.h
@@ -68,26 +68,26 @@ namespace dpp {
     datatools::multi_properties & operator()();
 
     /// Check initialization
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Initialize
-    virtual int initialize(const datatools::properties & config_,
-                           datatools::service_dict_type & service_dict_);
+    int initialize(const datatools::properties & config_,
+                           datatools::service_dict_type & service_dict_) override;
 
     /// Reset
-    virtual int reset();
+    int reset() override;
 
     /// Default constructor
     context_service();
 
     /// Destructor
-    virtual ~context_service();
+    ~context_service() override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   private:
 

--- a/source/bxdpp/include/dpp/dummy_module.h
+++ b/source/bxdpp/include/dpp/dummy_module.h
@@ -66,7 +66,7 @@ namespace dpp {
     dummy_module(datatools::logger::priority = datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~dummy_module();
+    ~dummy_module() override;
 
     /** Initialization method :
      *
@@ -77,18 +77,18 @@ namespace dpp {
      * \param mod_dict_ a reference to a dictionnary of pre-existing modules
      * (provided by some external agent)
      */
-    virtual void initialize(const datatools::properties & properties_,
+    void initialize(const datatools::properties & properties_,
                             datatools::service_manager & srv_mgr_,
-                            module_handle_dict_type & mod_dict_);
+                            module_handle_dict_type & mod_dict_) override;
 
     /// Termination method
-    virtual void reset();
+    void reset() override;
 
     /** Event processing method :
      *  \param data_record_ is a mutable reference to the data model instance to be processed.
      *  \return the error status of the data record processing
      */
-    virtual process_status process(datatools::things & data_record_);
+    process_status process(datatools::things & data_record_) override;
 
   private:
 

--- a/source/bxdpp/include/dpp/dump_module.h
+++ b/source/bxdpp/include/dpp/dump_module.h
@@ -69,24 +69,24 @@ namespace dpp {
     dump_module(datatools::logger::priority = datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~dump_module();
+    ~dump_module() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties & /* config_ */,
+    void initialize(const ::datatools::properties & /* config_ */,
                             datatools::service_manager & /* service_mgr_ */,
-                            dpp::module_handle_dict_type & /* modules_map_ */);
+                            dpp::module_handle_dict_type & /* modules_map_ */) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Data record processing
-    virtual process_status process(::datatools::things & /* data_ */);
+    process_status process(::datatools::things & /* data_ */) override;
 
     /// Smart print :
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
   protected:
 

--- a/source/bxdpp/include/dpp/histogram_service.h
+++ b/source/bxdpp/include/dpp/histogram_service.h
@@ -72,14 +72,14 @@ namespace dpp {
 
     histogram_service ();
 
-    virtual ~histogram_service ();
+    ~histogram_service () override;
 
-    virtual bool is_initialized () const;
+    bool is_initialized () const override;
 
-    virtual int initialize (const datatools::properties  & config_,
-                            datatools::service_dict_type & service_dict_);
+    int initialize (const datatools::properties  & config_,
+                            datatools::service_dict_type & service_dict_) override;
 
-    virtual int reset ();
+    int reset () override;
 
     void load_from_boost_file (const std::string & filename_);
 
@@ -87,10 +87,10 @@ namespace dpp {
 
     void store_as_root_file (const std::string & filename_) const;
 
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
     static void export_to_root (const mygsl::histogram_1d & h1d_,
                                 const std::string & name_,

--- a/source/bxdpp/include/dpp/if_module.h
+++ b/source/bxdpp/include/dpp/if_module.h
@@ -91,24 +91,24 @@ namespace dpp {
     if_module(datatools::logger::priority = datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~if_module();
+    ~if_module() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties & /* config_ */,
+    void initialize(const ::datatools::properties & /* config_ */,
                             datatools::service_manager & /* service_mgr_ */,
-                            dpp::module_handle_dict_type & /* modules_map_ */);
+                            dpp::module_handle_dict_type & /* modules_map_ */) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Data record processing
-    virtual process_status process(::datatools::things & /* data_ */);
+    process_status process(::datatools::things & /* data_ */) override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream      & out_    = std::clog,
+    void tree_dump (std::ostream      & out_    = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 

--- a/source/bxdpp/include/dpp/input_module.h
+++ b/source/bxdpp/include/dpp/input_module.h
@@ -85,24 +85,24 @@ namespace dpp {
     input_module(datatools::logger::priority = datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~input_module();
+    ~input_module() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties & /* config_ */,
+    void initialize(const ::datatools::properties & /* config_ */,
                             datatools::service_manager & /* service_mgr_ */,
-                            dpp::module_handle_dict_type & /* modules_map_ */);
+                            dpp::module_handle_dict_type & /* modules_map_ */) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Data record processing
-    virtual process_status process(::datatools::things & /* data_ */);
+    process_status process(::datatools::things & /* data_ */) override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & a_out         = std::clog,
+    void tree_dump(std::ostream & a_out         = std::clog,
                            const std::string & a_title  = "",
                            const std::string & a_indent = "",
-                           bool a_inherit          = false) const;
+                           bool a_inherit          = false) const override;
 
     /// Check input termination
     bool is_terminated() const;

--- a/source/bxdpp/include/dpp/module_manager.h
+++ b/source/bxdpp/include/dpp/module_manager.h
@@ -90,7 +90,7 @@ namespace dpp {
 
     module_manager(uint32_t flags_ = BLANK);
 
-    virtual ~module_manager();
+    ~module_manager() override;
 
     bool has_service_manager() const;
 
@@ -102,10 +102,10 @@ namespace dpp {
 
     void install_service_manager(const datatools::properties & service_manager_configuration_);
 
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     void load_module(const std::string & module_name_,
                      const std::string & module_id_,

--- a/source/bxdpp/include/dpp/module_tools.h
+++ b/source/bxdpp/include/dpp/module_tools.h
@@ -106,7 +106,7 @@ namespace dpp {
     module_entry_type();
 
     /// Destructor
-    virtual ~module_entry_type();
+    ~module_entry_type() override;
 
     /// Check is the module is referenced in the embedded handle
     bool has_module() const;
@@ -121,10 +121,10 @@ namespace dpp {
 
     module_handle_type & grab_initialized_module_handle();
 
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
   private:
 

--- a/source/bxdpp/include/dpp/output_module.h
+++ b/source/bxdpp/include/dpp/output_module.h
@@ -55,18 +55,18 @@ namespace dpp {
     output_module(datatools::logger::priority = datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~output_module();
+    ~output_module() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties & /* config_ */,
+    void initialize(const ::datatools::properties & /* config_ */,
                             datatools::service_manager & /* service_mgr_ */,
-                            dpp::module_handle_dict_type & /* modules_map_ */);
+                            dpp::module_handle_dict_type & /* modules_map_ */) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Data record processing
-    virtual process_status process(::datatools::things & /* data_ */);
+    process_status process(::datatools::things & /* data_ */) override;
 
     /// Set limits
     void set_limits(int max_record_total_,
@@ -104,10 +104,10 @@ namespace dpp {
     void clear_metadata_store();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
 
     /// Check output termination
     bool is_terminated() const;

--- a/source/bxdpp/include/dpp/simple_brio_data_sink.h
+++ b/source/bxdpp/include/dpp/simple_brio_data_sink.h
@@ -61,19 +61,19 @@ namespace dpp {
 
   public:
 
-    virtual bool is_random() const;
+    bool is_random() const override;
 
-    virtual void open();
+    void open() override;
 
-    virtual bool store_next_record(const datatools::things & a_event_record);
+    bool store_next_record(const datatools::things & a_event_record) override;
 
-    virtual bool can_store_meta_data() const;
+    bool can_store_meta_data() const override;
 
-    virtual bool store_metadata(const datatools::properties & a_meta_data);
+    bool store_metadata(const datatools::properties & a_meta_data) override;
 
-    virtual void close();
+    void close() override;
 
-    virtual void reset();
+    void reset() override;
 
   public:
 
@@ -86,7 +86,7 @@ namespace dpp {
                           datatools::logger::priority a_priority = datatools::logger::PRIO_NOTICE);
 
     /// Destructor
-    virtual ~simple_brio_data_sink();
+    ~simple_brio_data_sink() override;
 
   private:
 

--- a/source/bxdpp/include/dpp/simple_brio_data_source.h
+++ b/source/bxdpp/include/dpp/simple_brio_data_source.h
@@ -59,28 +59,28 @@ namespace dpp {
   {
   public:
 
-    virtual bool is_random() const;
+    bool is_random() const override;
 
-    virtual void open();
+    void open() override;
 
-    virtual bool has_next_record();
+    bool has_next_record() override;
 
-    virtual bool load_next_record(datatools::things & event_record_);
+    bool load_next_record(datatools::things & event_record_) override;
 
-    virtual int64_t get_number_of_metadata() const;
+    int64_t get_number_of_metadata() const override;
 
-    virtual bool load_metadata(datatools::properties & metadata_, int64_t entry_);
+    bool load_metadata(datatools::properties & metadata_, int64_t entry_) override;
 
-    virtual void close();
+    void close() override;
 
-    virtual void reset();
+    void reset() override;
 
     simple_brio_data_source(datatools::logger::priority priority = datatools::logger::PRIO_NOTICE);
 
     simple_brio_data_source(const std::string & source_label_,
                             datatools::logger::priority priority_ = datatools::logger::PRIO_NOTICE);
 
-    virtual ~simple_brio_data_source();
+    ~simple_brio_data_source() override;
 
   protected:
 
@@ -88,11 +88,11 @@ namespace dpp {
 
     virtual void _close_file_source();
 
-    virtual void _check_next_record();
+    void _check_next_record() override;
 
-    virtual int64_t _get_number_of_entries() const;
+    int64_t _get_number_of_entries() const override;
 
-    virtual bool _load_record(datatools::things & event_record_, int64_t entry_);
+    bool _load_record(datatools::things & event_record_, int64_t entry_) override;
 
   private:
 

--- a/source/bxdpp/include/dpp/simple_data_sink.h
+++ b/source/bxdpp/include/dpp/simple_data_sink.h
@@ -55,17 +55,17 @@ namespace dpp {
 
   public:
 
-    virtual void open();
+    void open() override;
 
-    virtual bool store_next_record(const datatools::things & event_record_);
+    bool store_next_record(const datatools::things & event_record_) override;
 
-    virtual bool can_store_meta_data() const;
+    bool can_store_meta_data() const override;
 
-    virtual bool store_metadata(const datatools::properties & meta_data_);
+    bool store_metadata(const datatools::properties & meta_data_) override;
 
-    virtual void close();
+    void close() override;
 
-    virtual void reset();
+    void reset() override;
 
     /// Constructor
     simple_data_sink(datatools::logger::priority priority_ = datatools::logger::PRIO_NOTICE);
@@ -76,7 +76,7 @@ namespace dpp {
                       datatools::logger::priority priority_ = datatools::logger::PRIO_NOTICE);
 
     /// Destructor
-    virtual ~simple_data_sink();
+    ~simple_data_sink() override;
 
   protected:
 

--- a/source/bxdpp/include/dpp/simple_data_source.h
+++ b/source/bxdpp/include/dpp/simple_data_source.h
@@ -73,26 +73,26 @@ namespace dpp {
 
   public:
 
-    virtual void open();
+    void open() override;
 
-    virtual bool has_next_record();
+    bool has_next_record() override;
 
-    virtual bool load_next_record(datatools::things & a_event_record_);
+    bool load_next_record(datatools::things & a_event_record_) override;
 
-    virtual int64_t get_number_of_metadata() const;
+    int64_t get_number_of_metadata() const override;
 
-    virtual bool load_metadata(datatools::properties & a_metadata_, int64_t a_entry_);
+    bool load_metadata(datatools::properties & a_metadata_, int64_t a_entry_) override;
 
-    virtual void close();
+    void close() override;
 
-    virtual void reset();
+    void reset() override;
 
     simple_data_source(datatools::logger::priority a_priority_ = datatools::logger::PRIO_NOTICE);
 
     simple_data_source(const std::string & a_source_label_,
                        datatools::logger::priority a_priority_ = datatools::logger::PRIO_NOTICE);
 
-    virtual ~simple_data_source();
+    ~simple_data_source() override;
 
   protected:
 
@@ -100,7 +100,7 @@ namespace dpp {
 
     virtual void _close_file_source();
 
-    virtual void _check_next_record();
+    void _check_next_record() override;
 
   private:
 

--- a/source/bxdpp/include/dpp/skip_module.h
+++ b/source/bxdpp/include/dpp/skip_module.h
@@ -52,18 +52,18 @@ namespace dpp {
     skip_module(datatools::logger::priority = datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~skip_module();
+    ~skip_module() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties & /* config_ */,
+    void initialize(const ::datatools::properties & /* config_ */,
                             datatools::service_manager & /* service_mgr_ */,
-                            dpp::module_handle_dict_type & /* modules_map_ */);
+                            dpp::module_handle_dict_type & /* modules_map_ */) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Data record processing
-    virtual process_status process(::datatools::things & /* data_ */);
+    process_status process(::datatools::things & /* data_ */) override;
 
     /// \brief Internal class of the skip_module class
     struct module_entry

--- a/source/bxdpp/include/dpp/utils_cut.h
+++ b/source/bxdpp/include/dpp/utils_cut.h
@@ -75,24 +75,24 @@ namespace dpp {
 
     utils_cut(datatools::logger::priority a_logging_priority =
               datatools::logger::PRIO_FATAL);
-    virtual ~utils_cut();
+    ~utils_cut() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties &,
+    void initialize(const datatools::properties &,
                             datatools::service_manager &,
-                            cuts::cut_handle_dict_type &);
+                            cuts::cut_handle_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
 
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
   protected:
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxdpp/include/dpp/utils_module.h
+++ b/source/bxdpp/include/dpp/utils_module.h
@@ -47,18 +47,18 @@ namespace dpp {
     utils_module(datatools::logger::priority = datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~utils_module();
+    ~utils_module() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties & /* config_ */,
+    void initialize(const ::datatools::properties & /* config_ */,
                             datatools::service_manager & /* service_mgr_ */,
-                            dpp::module_handle_dict_type & /* modules_map_ */);
+                            dpp::module_handle_dict_type & /* modules_map_ */) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Data record processing
-    virtual process_status process(::datatools::things & /* data_ */);
+    process_status process(::datatools::things & /* data_ */) override;
 
   protected:
 

--- a/source/bxemfield/include/emfield/base_electromagnetic_field.h
+++ b/source/bxemfield/include/emfield/base_electromagnetic_field.h
@@ -115,7 +115,7 @@ namespace emfield {
     base_electromagnetic_field(uint32_t flags_ = 0);
 
     /// Destructor
-    virtual ~base_electromagnetic_field();
+    ~base_electromagnetic_field() override;
 
     /// Compute the coordinates of the electric and magnetic fields at given position and time
     virtual int compute_electromagnetic_field(const geomtools::vector_3d & position_,
@@ -169,10 +169,10 @@ namespace emfield {
                                        geomtools::vector_3d & magnetic_field_) const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   protected:
 

--- a/source/bxemfield/include/emfield/electromagnetic_field_macros.h
+++ b/source/bxemfield/include/emfield/electromagnetic_field_macros.h
@@ -158,7 +158,7 @@
   private:                                                              \
   DATATOOLS_FACTORY_SYSTEM_AUTO_REGISTRATION_INTERFACE(::emfield::base_electromagnetic_field,EMFIELD_CLASS_NAME) \
   public:                                                               \
-  virtual std::string get_class_id() const;                             \
+  std::string get_class_id() const override;                             \
 
 
 #define EMFIELD_REGISTRATION_IMPLEMENT(EMFIELD_CLASS_NAME,EMFIELD_ID)   \

--- a/source/bxemfield/include/emfield/electromagnetic_field_manager.h
+++ b/source/bxemfield/include/emfield/electromagnetic_field_manager.h
@@ -100,7 +100,7 @@ namespace emfield {
     electromagnetic_field_manager(uint32_t flags_ = 0);
 
     /// Destructor
-    virtual ~electromagnetic_field_manager();
+    ~electromagnetic_field_manager() override;
 
     /// Initialize the manager
     void initialize(const datatools::properties & setup_);
@@ -112,10 +112,10 @@ namespace emfield {
     void load(const std::string & field_definitions_filename_);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
     /// Return the dictionary of created fields
     const base_electromagnetic_field::field_dict_type & get_fields() const;

--- a/source/bxemfield/include/emfield/emfield_geom_plugin.h
+++ b/source/bxemfield/include/emfield/emfield_geom_plugin.h
@@ -44,18 +44,18 @@ namespace emfield {
     emfield_geom_plugin ();
 
     /// Destructor
-    virtual ~emfield_geom_plugin ();
+    ~emfield_geom_plugin () override;
 
     /// Main initialization method
-    virtual int initialize(const datatools::properties & config_,
+    int initialize(const datatools::properties & config_,
                            const geomtools::manager::plugins_dict_type & plugins_,
-                           const datatools::service_dict_type & services_);
+                           const datatools::service_dict_type & services_) override;
 
     /// Main reset method
-    virtual int reset();
+    int reset() override;
 
     /// Check if plugin is initialized
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Return a non-mutable reference on a manager of isotopes, elements and emfield
     const electromagnetic_field_manager & get_manager () const;

--- a/source/bxemfield/include/emfield/geom_map.h
+++ b/source/bxemfield/include/emfield/geom_map.h
@@ -74,7 +74,7 @@ namespace emfield {
 
     geom_map();
 
-    virtual ~geom_map();
+    ~geom_map() override;
 
     const association_dict_type & get_associations() const;
 
@@ -102,10 +102,10 @@ namespace emfield {
 
     const electromagnetic_field_manager & get_fields_manager() const;
 
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title = "",
                            const std::string & indent_= "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected :
 

--- a/source/bxemfield/include/emfield/linear_combination_field.h
+++ b/source/bxemfield/include/emfield/linear_combination_field.h
@@ -46,25 +46,25 @@ namespace emfield {
     linear_combination_field(uint32_t = 0);
 
     /// Destructor
-    virtual ~linear_combination_field();
+    ~linear_combination_field() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                             ::datatools::service_manager &,
-                            ::emfield::base_electromagnetic_field::field_dict_type &);
+                            ::emfield::base_electromagnetic_field::field_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Compute electric field
-    virtual int compute_electric_field(const ::geomtools::vector_3d & position_,
+    int compute_electric_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       ::geomtools::vector_3d & electric_field_) const;
+                                       ::geomtools::vector_3d & electric_field_) const override;
 
     /// Compute magnetic field
-    virtual int compute_magnetic_field(const ::geomtools::vector_3d & position_,
+    int compute_magnetic_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       geomtools::vector_3d & magnetic_field_) const;
+                                       geomtools::vector_3d & magnetic_field_) const override;
 
     /// Add a combined field
     void add_combined_field (const std::string & label_,
@@ -73,10 +73,10 @@ namespace emfield {
                              bool force_combined_ = false);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   private:
 

--- a/source/bxemfield/include/emfield/multi_zone_field.h
+++ b/source/bxemfield/include/emfield/multi_zone_field.h
@@ -96,25 +96,25 @@ namespace emfield {
     multi_zone_field(uint32_t = 0);
 
     /// Destructor
-    virtual ~multi_zone_field();
+    ~multi_zone_field() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                             ::datatools::service_manager &,
-                            ::emfield::base_electromagnetic_field::field_dict_type &);
+                            ::emfield::base_electromagnetic_field::field_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Compute electric field
-    virtual int compute_electric_field(const ::geomtools::vector_3d & position_,
+    int compute_electric_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       ::geomtools::vector_3d & electric_field_) const;
+                                       ::geomtools::vector_3d & electric_field_) const override;
 
     /// Compute magnetic field
-    virtual int compute_magnetic_field(const ::geomtools::vector_3d & position_,
+    int compute_magnetic_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       geomtools::vector_3d & magnetic_field_) const;
+                                       geomtools::vector_3d & magnetic_field_) const override;
 
     /// Add a zone field
     void add_zone_field(const std::string & zone_label_,
@@ -148,10 +148,10 @@ namespace emfield {
     void create_shape_factory(const ::datatools::properties & setup_);
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
   protected:
 

--- a/source/bxemfield/include/emfield/oscillating_field.h
+++ b/source/bxemfield/include/emfield/oscillating_field.h
@@ -56,25 +56,25 @@ namespace emfield {
     oscillating_field(uint32_t = 0);
 
     /// Destructor
-    virtual ~oscillating_field();
+    ~oscillating_field() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                             ::datatools::service_manager &,
-                            ::emfield::base_electromagnetic_field::field_dict_type &);
+                            ::emfield::base_electromagnetic_field::field_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Compute electric field
-    virtual int compute_electric_field(const ::geomtools::vector_3d & position_,
+    int compute_electric_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       ::geomtools::vector_3d & electric_field_) const;
+                                       ::geomtools::vector_3d & electric_field_) const override;
 
     /// Compute magnetic field
-    virtual int compute_magnetic_field(const ::geomtools::vector_3d & position_,
+    int compute_magnetic_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       geomtools::vector_3d & magnetic_field_) const;
+                                       geomtools::vector_3d & magnetic_field_) const override;
 
     void set_sine_cosine_mode(mode_sin_cos_type);
 
@@ -103,10 +103,10 @@ namespace emfield {
     void set_field (base_electromagnetic_field::handle_type &);
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
   protected:
 

--- a/source/bxemfield/include/emfield/placement_field.h
+++ b/source/bxemfield/include/emfield/placement_field.h
@@ -37,25 +37,25 @@ namespace emfield {
     placement_field(uint32_t = 0);
 
     /// Destructor
-    virtual ~placement_field();
+    ~placement_field() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                             ::datatools::service_manager &,
-                            ::emfield::base_electromagnetic_field::field_dict_type &);
+                            ::emfield::base_electromagnetic_field::field_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Compute electric field
-    virtual int compute_electric_field(const ::geomtools::vector_3d & position_,
+    int compute_electric_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       ::geomtools::vector_3d & electric_field_) const;
+                                       ::geomtools::vector_3d & electric_field_) const override;
 
     /// Compute magnetic field
-    virtual int compute_magnetic_field(const ::geomtools::vector_3d & position_,
+    int compute_magnetic_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       geomtools::vector_3d & magnetic_field_) const;
+                                       geomtools::vector_3d & magnetic_field_) const override;
 
     /// Return the placement
     const geomtools::placement & get_placement() const;
@@ -67,10 +67,10 @@ namespace emfield {
     void set_field(base_electromagnetic_field::handle_type &);
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
   protected:
 

--- a/source/bxemfield/include/emfield/polynomial_magnetic_field.h
+++ b/source/bxemfield/include/emfield/polynomial_magnetic_field.h
@@ -54,31 +54,31 @@ namespace emfield {
     polynomial_magnetic_field(uint32_t flags_ = 0);
 
     /// Destructor
-    virtual ~polynomial_magnetic_field();
+    ~polynomial_magnetic_field() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties & setup_,
+    void initialize(const datatools::properties & setup_,
                             datatools::service_manager & service_manager_,
-                            emfield::base_electromagnetic_field::field_dict_type & dict_);
+                            emfield::base_electromagnetic_field::field_dict_type & dict_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Main function to compute electric field
-    virtual int compute_electric_field(const geomtools::vector_3d & position_,
+    int compute_electric_field(const geomtools::vector_3d & position_,
                                        double time_,
-                                       geomtools::vector_3d & electric_field_) const;
+                                       geomtools::vector_3d & electric_field_) const override;
 
     /// Main function to compute magnetic field
-    virtual int compute_magnetic_field(const geomtools::vector_3d & position_,
+    int compute_magnetic_field(const geomtools::vector_3d & position_,
                                        double time_,
-                                       geomtools::vector_3d & magnetic_field_) const;
+                                       geomtools::vector_3d & magnetic_field_) const override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
   private:
 

--- a/source/bxemfield/include/emfield/uniform_electric_field.h
+++ b/source/bxemfield/include/emfield/uniform_electric_field.h
@@ -32,35 +32,35 @@ namespace emfield {
     uniform_electric_field(uint32_t = 0);
 
     /// Destructor
-    virtual ~uniform_electric_field();
+    ~uniform_electric_field() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                             ::datatools::service_manager &,
-                            ::emfield::base_electromagnetic_field::field_dict_type &);
+                            ::emfield::base_electromagnetic_field::field_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Compute electric field
-    virtual int compute_electric_field(const ::geomtools::vector_3d & position_,
+    int compute_electric_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       ::geomtools::vector_3d & electric_field_) const;
+                                       ::geomtools::vector_3d & electric_field_) const override;
 
     /// Compute magnetic field
-    virtual int compute_magnetic_field(const ::geomtools::vector_3d & position_,
+    int compute_magnetic_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       geomtools::vector_3d & magnetic_field_) const;
+                                       geomtools::vector_3d & magnetic_field_) const override;
 
     const geomtools::vector_3d & get_uniform_electric_field () const;
 
     void set_uniform_electric_field (const geomtools::vector_3d & b_);
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
   protected:
 

--- a/source/bxemfield/include/emfield/uniform_magnetic_field.h
+++ b/source/bxemfield/include/emfield/uniform_magnetic_field.h
@@ -32,25 +32,25 @@ namespace emfield {
     uniform_magnetic_field(uint32_t = 0);
 
     /// Destructor
-    virtual ~uniform_magnetic_field();
+    ~uniform_magnetic_field() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                             ::datatools::service_manager &,
-                            ::emfield::base_electromagnetic_field::field_dict_type &);
+                            ::emfield::base_electromagnetic_field::field_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Compute electric field
-    virtual int compute_electric_field(const ::geomtools::vector_3d & position_,
+    int compute_electric_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       ::geomtools::vector_3d & electric_field_) const;
+                                       ::geomtools::vector_3d & electric_field_) const override;
 
     /// Compute magnetic field
-    virtual int compute_magnetic_field(const ::geomtools::vector_3d & position_,
+    int compute_magnetic_field(const ::geomtools::vector_3d & position_,
                                        double time_,
-                                       geomtools::vector_3d & magnetic_field_) const;
+                                       geomtools::vector_3d & magnetic_field_) const override;
 
 
     const geomtools::vector_3d & get_uniform_magnetic_field() const;
@@ -58,10 +58,10 @@ namespace emfield {
     void set_uniform_magnetic_field(const geomtools::vector_3d & b_);
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
   protected:
 

--- a/source/bxepa/include/boost/archive/portable_archive_exception.hpp
+++ b/source/bxepa/include/boost/archive/portable_archive_exception.hpp
@@ -83,8 +83,8 @@ namespace boost {
 			}
 
 			//! override the base class function with our message
-			const char* what() const throw() { return msg.c_str(); }
-			~portable_archive_exception() throw() {}
+			const char* what() const throw() override { return msg.c_str(); }
+			~portable_archive_exception() throw() override {}
 		};
 
 	} // namespace archive

--- a/source/bxgenbb_help/include/genbb_help/alpha_decay.h
+++ b/source/bxgenbb_help/include/genbb_help/alpha_decay.h
@@ -63,7 +63,7 @@ namespace genbb {
     alpha_decay();
 
     /// Destructor
-    virtual ~alpha_decay();
+    ~alpha_decay() override;
 
     /// Check if Q alpha is set
     bool has_q_alpha() const;
@@ -141,13 +141,13 @@ namespace genbb {
     void set_daughter_generated(bool);
 
     /// Set the transition parameter from the start and stop levels
-    void set_levels(const nuclear_level & lstart_, const nuclear_level & lstop_);
+    void set_levels(const nuclear_level & lstart_, const nuclear_level & lstop_) override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Shoot the kinematics of the decay:
     /// @arg prng_ The pseudo-random number generator
@@ -163,13 +163,13 @@ namespace genbb {
                               double & phir_) const;
 
     /// Initialization
-    virtual void initialize(const datatools::properties & config_);
+    void initialize(const datatools::properties & config_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Shoot the kinematics of the decay and fill a primary event
-    virtual int fill(mygsl::rng & prng_, genbb::primary_event & event_);
+    int fill(mygsl::rng & prng_, genbb::primary_event & event_) override;
 
   protected:
 

--- a/source/bxgenbb_help/include/genbb_help/base_decay_driver.h
+++ b/source/bxgenbb_help/include/genbb_help/base_decay_driver.h
@@ -65,7 +65,7 @@ namespace genbb {
     base_decay_driver();
 
     /// Destructor
-    virtual ~base_decay_driver();
+    ~base_decay_driver() override;
 
     /// Return the logging priority threshold
     datatools::logger::priority get_logging() const;
@@ -74,10 +74,10 @@ namespace genbb {
     void set_logging(datatools::logger::priority);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Check initialization status
     bool is_initialized() const;

--- a/source/bxgenbb_help/include/genbb_help/beta_decay.h
+++ b/source/bxgenbb_help/include/genbb_help/beta_decay.h
@@ -118,7 +118,7 @@ namespace genbb {
     beta_decay();
 
     /// Destructor
-    virtual ~beta_decay();
+    ~beta_decay() override;
 
     /// Set the type of the beta decay
     void set_type(decay_type);
@@ -268,10 +268,10 @@ namespace genbb {
                                   double & ke_max_);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Display PDF
     void display_pdf(const std::string & title_ = "") const;
@@ -290,17 +290,17 @@ namespace genbb {
                               double & cenu_) const;
 
     /// Set the transition parameter from the start and stop levels
-    virtual void set_levels(const nuclear_level & level_start_,
-                            const nuclear_level & level_stop_);
+    void set_levels(const nuclear_level & level_start_,
+                            const nuclear_level & level_stop_) override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties & config_);
+    void initialize(const datatools::properties & config_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Shoot the kinematics of the decay and fill a primary event
-    virtual int fill(mygsl::rng & prng_, genbb::primary_event & event_);
+    int fill(mygsl::rng & prng_, genbb::primary_event & event_) override;
 
   protected:
 

--- a/source/bxgenbb_help/include/genbb_help/combined_particle_generator.h
+++ b/source/bxgenbb_help/include/genbb_help/combined_particle_generator.h
@@ -107,7 +107,7 @@ namespace genbb {
     bool is_mode_activity() const;
 
     /// Check existence of external random
-    virtual bool can_external_random() const;
+    bool can_external_random() const override;
 
     /// Return a non-mutable random generator
     const mygsl::rng & get_random() const;
@@ -119,21 +119,21 @@ namespace genbb {
     combined_particle_generator();
 
     /// Destructor
-    virtual ~combined_particle_generator();
+    ~combined_particle_generator() override;
 
     /// Main initialization interface method
-    virtual void initialize(const datatools::properties & setup_,
+    void initialize(const datatools::properties & setup_,
                             datatools::service_manager & service_manager_,
-                            detail::pg_dict_type & dictionary_);
+                            detail::pg_dict_type & dictionary_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check next generation event
-    virtual bool has_next();
+    bool has_next() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Smart dump
     void dump(std::ostream & out_, const std::string & title_, const std::string & indent_ = "") const;
@@ -141,8 +141,8 @@ namespace genbb {
   protected:
 
     /// Main generation function
-    virtual void _load_next(primary_event & event_,
-                            bool compute_classification_ = true);
+    void _load_next(primary_event & event_,
+                            bool compute_classification_ = true) override;
 
   private:
 

--- a/source/bxgenbb_help/include/genbb_help/from_file_generator.h
+++ b/source/bxgenbb_help/include/genbb_help/from_file_generator.h
@@ -54,26 +54,26 @@ namespace genbb {
     from_file_generator();
 
     /// Destructor
-    virtual ~from_file_generator();
+    ~from_file_generator() override;
 
     /// Main initialization interface method
-    virtual void initialize(const datatools::properties & setup_,
+    void initialize(const datatools::properties & setup_,
                             datatools::service_manager & service_manager_,
-                            detail::pg_dict_type & dictionary_);
+                            detail::pg_dict_type & dictionary_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check if the generator has a next event
-    virtual bool has_next();
+    bool has_next() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected:
 
-    virtual void _load_next(primary_event & event_,
-                            bool compute_classification_ = true);
+    void _load_next(primary_event & event_,
+                            bool compute_classification_ = true) override;
 
   private:
 

--- a/source/bxgenbb_help/include/genbb_help/genbb_mgr.h
+++ b/source/bxgenbb_help/include/genbb_help/genbb_mgr.h
@@ -85,26 +85,26 @@ namespace genbb {
     genbb_mgr (int format_ = FORMAT_GENBB);
 
     /// Destructor
-    virtual ~genbb_mgr ();
+    ~genbb_mgr () override;
 
     void dump (std::ostream & out_ = std::clog) const;
 
     void set (const std::string & filename_);
 
-    virtual bool is_initialized () const;
+    bool is_initialized () const override;
 
-    virtual void initialize (const datatools::properties & config_,
+    void initialize (const datatools::properties & config_,
                              datatools::service_manager & service_manager_,
-                             detail::pg_dict_type & dictionary_);
+                             detail::pg_dict_type & dictionary_) override;
 
-    virtual void reset ();
+    void reset () override;
 
-    virtual bool has_next ();
+    bool has_next () override;
 
   protected:
 
-    virtual void _load_next (primary_event & event_,
-                             bool compute_classification_ = true);
+    void _load_next (primary_event & event_,
+                             bool compute_classification_ = true) override;
 
   private:
 

--- a/source/bxgenbb_help/include/genbb_help/i_genbb.h
+++ b/source/bxgenbb_help/include/genbb_help/i_genbb.h
@@ -76,7 +76,7 @@ namespace genbb {
     i_genbb();
 
     /// Destructor
-    virtual ~i_genbb();
+    ~i_genbb() override;
 
     /// Load a new 'primary_event' object
     virtual void load_next(primary_event & event_,
@@ -144,10 +144,10 @@ namespace genbb {
     bool is_assign_generation_ids() const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream& out = std::clog,
+    void tree_dump(std::ostream& out = std::clog,
                            const std::string& title  = "",
                            const std::string& indent = "",
-                           bool inherit = false) const;
+                           bool inherit = false) const override;
 
     /// OCD interface
     static void base_initialize_ocd(datatools::object_configuration_description &);

--- a/source/bxgenbb_help/include/genbb_help/lorentz_boost_wrapper.h
+++ b/source/bxgenbb_help/include/genbb_help/lorentz_boost_wrapper.h
@@ -121,27 +121,27 @@ namespace genbb {
     lorentz_boost_wrapper();
 
     /// Destructor
-    virtual ~lorentz_boost_wrapper();
+    ~lorentz_boost_wrapper() override;
 
     /// Main initialization interface method
-    virtual void initialize(const datatools::properties & setup_,
+    void initialize(const datatools::properties & setup_,
                             datatools::service_manager & service_manager_,
-                            detail::pg_dict_type & dictionary_);
+                            detail::pg_dict_type & dictionary_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check if the generator has a next event
-    virtual bool has_next();
+    bool has_next() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected:
 
     /// Load next primary event from the generator algorithm
-    virtual void _load_next(primary_event & event_,
-                            bool compute_classification_ = true);
+    void _load_next(primary_event & event_,
+                            bool compute_classification_ = true) override;
 
   private:
 

--- a/source/bxgenbb_help/include/genbb_help/manager.h
+++ b/source/bxgenbb_help/include/genbb_help/manager.h
@@ -88,7 +88,7 @@ namespace genbb {
     manager(datatools::logger::priority p_ = datatools::logger::PRIO_WARNING, int flags_ = 0);
 
     /// Destructor
-    ~manager();
+    ~manager() override;
 
     /// Check the debug flag
     bool is_debug() const;
@@ -208,10 +208,10 @@ namespace genbb {
                                    const std::string & mode_ = "") const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     const datatools::factory_register<i_genbb> & get_factory_register() const;
 

--- a/source/bxgenbb_help/include/genbb_help/nuclear_decay.h
+++ b/source/bxgenbb_help/include/genbb_help/nuclear_decay.h
@@ -62,7 +62,7 @@ namespace genbb {
     nuclear_decay();
 
     /// Destructor
-    virtual ~nuclear_decay();
+    ~nuclear_decay() override;
 
     /// Check validity
     bool is_valid() const;
@@ -114,10 +114,10 @@ namespace genbb {
     std::string to_string(unsigned int = 0) const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Check the decay driver avaibility
     bool has_decay_driver() const;

--- a/source/bxgenbb_help/include/genbb_help/nuclear_decay_generator.h
+++ b/source/bxgenbb_help/include/genbb_help/nuclear_decay_generator.h
@@ -58,27 +58,27 @@ namespace genbb {
     nuclear_decay_generator();
 
     /// Destructor
-    virtual ~nuclear_decay_generator();
+    ~nuclear_decay_generator() override;
 
     /// Main initialization interface method
-    virtual void initialize(const datatools::properties & setup_,
+    void initialize(const datatools::properties & setup_,
                             datatools::service_manager & service_manager_,
-                            detail::pg_dict_type & dictionary_);
+                            detail::pg_dict_type & dictionary_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check if the generator has a next event
-    virtual bool has_next();
+    bool has_next() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Return the Local PRNG's seed
     unsigned long get_seed() const;
 
     /// Accept external PRNG
-    virtual bool can_external_random() const;
+    bool can_external_random() const override;
 
     /// Return the active PRNG
     const mygsl::rng & get_random() const;
@@ -89,7 +89,7 @@ namespace genbb {
   protected:
 
     /// Generate the next event:
-    virtual void _load_next(primary_event & event_, bool compute_classification_);
+    void _load_next(primary_event & event_, bool compute_classification_) override;
 
   private:
 

--- a/source/bxgenbb_help/include/genbb_help/nuclear_decay_manager.h
+++ b/source/bxgenbb_help/include/genbb_help/nuclear_decay_manager.h
@@ -74,7 +74,7 @@ namespace genbb {
     nuclear_decay_manager();
 
     /// Destructor
-    virtual ~nuclear_decay_manager();
+    ~nuclear_decay_manager() override;
 
     /// Load a nuclear level
     void load_level(const std::string & level_name_,
@@ -112,10 +112,10 @@ namespace genbb {
     const decay_dict_type & get_decays() const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 

--- a/source/bxgenbb_help/include/genbb_help/nuclear_level.h
+++ b/source/bxgenbb_help/include/genbb_help/nuclear_level.h
@@ -131,7 +131,7 @@ namespace genbb {
     nuclear_level();
 
     /// Desstructor
-    virtual ~nuclear_level();
+    ~nuclear_level() override;
 
     /// Check validity
     bool is_valid() const;
@@ -233,10 +233,10 @@ namespace genbb {
     std::string to_string(unsigned int = 0) const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Check initialization flag
     bool is_initialized() const;

--- a/source/bxgenbb_help/include/genbb_help/nuclear_transition.h
+++ b/source/bxgenbb_help/include/genbb_help/nuclear_transition.h
@@ -81,7 +81,7 @@ namespace genbb {
     nuclear_transition();
 
     /// Destructor
-    virtual ~nuclear_transition();
+    ~nuclear_transition() override;
 
     /// Check if A is set
     bool has_A() const;
@@ -171,13 +171,13 @@ namespace genbb {
     void set_conversion_pair_generated(bool);
 
     /// Set the transition parameter from the start and stop levels
-    void set_levels(const nuclear_level & lstart_, const nuclear_level & lstop_);
+    void set_levels(const nuclear_level & lstart_, const nuclear_level & lstop_) override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Shoot the kinematics of the gamma emission, internal conversion + X-rays or pair conversion:
     /// @arg prng_ The pseudo-random number generator
@@ -204,13 +204,13 @@ namespace genbb {
                               double & phi2_) const;
 
     /// Initialization
-    virtual void initialize(const datatools::properties & config_);
+    void initialize(const datatools::properties & config_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Shoot the kinematics of the decay and fill a primary event
-    virtual int fill(mygsl::rng & prng_, genbb::primary_event & event_);
+    int fill(mygsl::rng & prng_, genbb::primary_event & event_) override;
 
   protected:
 

--- a/source/bxgenbb_help/include/genbb_help/pdg_particle_tools.h
+++ b/source/bxgenbb_help/include/genbb_help/pdg_particle_tools.h
@@ -140,7 +140,7 @@ namespace genbb {
                const std::string & latex_repr_);
 
       /// Destructor
-      virtual ~particle();
+      ~particle() override;
 
       /// Check validity
       bool is_valid() const;
@@ -182,10 +182,10 @@ namespace genbb {
       datatools::properties & grab_auxiliaries();
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// Build the nuclear code from (Z, A and isomer level).
       /// This is not for single hadrons like p, n,...
@@ -220,7 +220,7 @@ namespace genbb {
       particle_registry(uint32_t flags_ = 0);
 
       /// Destructor
-      ~particle_registry();
+      ~particle_registry() override;
 
       /// Clear the registry
       void clear();
@@ -247,10 +247,10 @@ namespace genbb {
       const particle & get_particle_by_name(const std::string & name_) const;
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_ = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
       /// Register standard particles
       void register_standard_particles();

--- a/source/bxgenbb_help/include/genbb_help/primary_event.h
+++ b/source/bxgenbb_help/include/genbb_help/primary_event.h
@@ -178,7 +178,7 @@ namespace genbb {
     primary_event();
 
     /// Destructor
-    virtual ~primary_event();
+    ~primary_event() override;
 
     /// Smart print
     void print_tree(std::ostream & out_ = std::clog,

--- a/source/bxgenbb_help/include/genbb_help/primary_particle.h
+++ b/source/bxgenbb_help/include/genbb_help/primary_particle.h
@@ -358,7 +358,7 @@ namespace genbb {
                      const geomtools::vector_3d &);
 
     /// Destructor
-    virtual ~primary_particle();
+    ~primary_particle() override;
 
     /// Smart print
     void print_tree(std::ostream & out_ = std::clog,

--- a/source/bxgenbb_help/include/genbb_help/save_to_file_wrapper.h
+++ b/source/bxgenbb_help/include/genbb_help/save_to_file_wrapper.h
@@ -60,27 +60,27 @@ namespace genbb {
     save_to_file_wrapper();
 
     /// Destructor
-    virtual ~save_to_file_wrapper();
+    ~save_to_file_wrapper() override;
 
     /// Main initialization interface method
-    virtual void initialize(const datatools::properties & setup_,
+    void initialize(const datatools::properties & setup_,
                             datatools::service_manager & service_manager_,
-                            detail::pg_dict_type & dictionary_);
+                            detail::pg_dict_type & dictionary_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check if the generator has a next event
-    virtual bool has_next();
+    bool has_next() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected:
 
     /// Load next primary event from the generator algorithm
-    virtual void _load_next(primary_event & event_,
-                            bool compute_classification_ = true);
+    void _load_next(primary_event & event_,
+                            bool compute_classification_ = true) override;
 
   private:
 

--- a/source/bxgenbb_help/include/genbb_help/single_particle_generator.h
+++ b/source/bxgenbb_help/include/genbb_help/single_particle_generator.h
@@ -122,7 +122,7 @@ namespace genbb {
     double get_particle_mass() const;
     void set_particle_mass(double);
 
-    virtual bool can_external_random() const;
+    bool can_external_random() const override;
     const mygsl::rng & get_random() const;
     mygsl::rng & grab_random();
 
@@ -154,21 +154,21 @@ namespace genbb {
     single_particle_generator();
 
     /// Destructor
-    virtual ~single_particle_generator();
+    ~single_particle_generator() override;
 
     /// Main initialization interface method
-    virtual void initialize(const datatools::properties & setup_,
+    void initialize(const datatools::properties & setup_,
                              datatools::service_manager & service_manager_,
-                             detail::pg_dict_type & dictionary_);
+                             detail::pg_dict_type & dictionary_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check if a next primary event is available
-    virtual bool has_next();
+    bool has_next() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     static double get_particle_mass_from_label(const std::string & particle_name_);
 
@@ -177,8 +177,8 @@ namespace genbb {
   protected:
 
     /// Shoot the primary event
-    virtual void _load_next(primary_event & event_,
-                            bool compute_classification_ = true);
+    void _load_next(primary_event & event_,
+                            bool compute_classification_ = true) override;
 
     /// Insitialize the energy spectrum
     void _init_energy_spectrum();

--- a/source/bxgenbb_help/include/genbb_help/time_slicer_generator.h
+++ b/source/bxgenbb_help/include/genbb_help/time_slicer_generator.h
@@ -110,33 +110,33 @@ namespace genbb {
     bool is_record_original_event_id() const;
 
     /// Check if the generator accepts an external PRNG
-    virtual bool can_external_random() const;
+    bool can_external_random() const override;
 
     /// Constructor
     time_slicer_generator();
 
     /// Destructor
-    virtual ~time_slicer_generator();
+    ~time_slicer_generator() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Main initialization interface method
-    virtual void initialize(const datatools::properties & setup_,
+    void initialize(const datatools::properties & setup_,
                             datatools::service_manager & service_manager_,
-                            detail::pg_dict_type & dictionary_);
+                            detail::pg_dict_type & dictionary_) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check if a next primary event is available
-    virtual bool has_next();
+    bool has_next() override;
 
   protected:
 
     /// Main generation function
-    virtual void _load_next(primary_event & event_,
-                            bool compute_classification_ = true);
+    void _load_next(primary_event & event_,
+                            bool compute_classification_ = true) override;
 
   private:
 

--- a/source/bxgenbb_help/include/genbb_help/wdecay0.h
+++ b/source/bxgenbb_help/include/genbb_help/wdecay0.h
@@ -69,9 +69,9 @@ namespace genbb {
 
     wdecay0();
 
-    virtual ~wdecay0();
+    ~wdecay0() override;
 
-    virtual bool can_external_random() const;
+    bool can_external_random() const override;
 
     const mygsl::rng & get_random() const;
 
@@ -81,27 +81,27 @@ namespace genbb {
 
     double get_to_all_events() const;
 
-    virtual void tree_dump(std::ostream & out = std::clog,
+    void tree_dump(std::ostream & out = std::clog,
                            const std::string & title  = "",
                            const std::string & indent = "",
-                           bool inherit = false) const;
+                           bool inherit = false) const override;
 
     void dump(std::ostream & = std::clog) const;
 
-    virtual void initialize(const datatools::properties & setup_,
+    void initialize(const datatools::properties & setup_,
                             datatools::service_manager & service_manager_,
-                            detail::pg_dict_type & dictionary_);
+                            detail::pg_dict_type & dictionary_) override;
 
-    virtual void reset();
+    void reset() override;
 
-    virtual bool has_next();
+    bool has_next() override;
 
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected:
 
-    virtual void _load_next(primary_event & event_,
-                            bool compute_classification_ = true);
+    void _load_next(primary_event & event_,
+                            bool compute_classification_ = true) override;
 
   private:
 

--- a/source/bxgenbb_help/programs/genbb_inspector.cxx
+++ b/source/bxgenbb_help/programs/genbb_inspector.cxx
@@ -197,6 +197,8 @@ namespace genbb {
   {
   public:
     inspector_data();
+    // Required by use of CAMP RTTI
+    virtual ~inspector_data() = default;
     void reset();
     void sort();
 

--- a/source/bxgenvtx/include/genvtx/box_model_vg.h
+++ b/source/bxgenvtx/include/genvtx/box_model_vg.h
@@ -40,7 +40,7 @@ namespace genvtx {
     box_model_vg();
 
     /// Destructor
-    virtual ~box_model_vg();
+    ~box_model_vg() override;
 
     /// Check the validity of the mode
     bool is_mode_valid() const;
@@ -106,26 +106,26 @@ namespace genvtx {
     bool is_using_bounding_box();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                             ::datatools::service_manager &,
-                            ::genvtx::vg_dict_type &);
+                            ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
     /// Main vertex randomization algorithm
     void _shoot_vertex_boxes(mygsl::rng & random_, geomtools::vector_3d & vertex_);

--- a/source/bxgenvtx/include/genvtx/box_vg.h
+++ b/source/bxgenvtx/include/genvtx/box_vg.h
@@ -100,29 +100,29 @@ namespace genvtx {
     void tree_dump (std::ostream & out_ = std::clog,
                     const std::string & title_ = "",
                     const std::string & indent_ = "",
-                    bool inherit_ = false) const;
+                    bool inherit_ = false) const override;
 
     /// Constructor
     box_vg();
 
     /// Destructor
-    virtual ~box_vg();
+    ~box_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                              ::datatools::service_manager &,
-                             ::genvtx::vg_dict_type &);
+                             ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
   private:
 

--- a/source/bxgenvtx/include/genvtx/combined_vg.h
+++ b/source/bxgenvtx/include/genvtx/combined_vg.h
@@ -52,33 +52,33 @@ namespace genvtx {
                         double a_weight = 1.0);
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_ = std::clog,
+    void tree_dump (std::ostream & out_ = std::clog,
                             const std::string & title_ = "",
                             const std::string & indent_ = "",
-                            bool inherit_ = false) const;
+                            bool inherit_ = false) const override;
 
     /// Constructor
     combined_vg();
 
     /// Destructor
-    virtual ~combined_vg();
+    ~combined_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                              ::datatools::service_manager &,
-                             ::genvtx::vg_dict_type &);
+                             ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected:
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_,
-                               ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_,
+                               ::geomtools::vector_3d & vertex_) override;
 
     /// Main algorithm
     void _shoot_vertex_combined (mygsl::rng & random_,

--- a/source/bxgenvtx/include/genvtx/cylinder_model_vg.h
+++ b/source/bxgenvtx/include/genvtx/cylinder_model_vg.h
@@ -63,32 +63,32 @@ namespace genvtx {
 
     void set_mode (int);
 
-    virtual void tree_dump (std::ostream & out_ = std::clog,
+    void tree_dump (std::ostream & out_ = std::clog,
                             const std::string & title_ = "",
                             const std::string & indent_ = "",
-                            bool inherit_ = false) const;
+                            bool inherit_ = false) const override;
 
     /// Constructor
     cylinder_model_vg();
 
     /// Destructor
-    virtual ~cylinder_model_vg();
+    ~cylinder_model_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                             ::datatools::service_manager &,
-                            ::genvtx::vg_dict_type &);
+                            ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
     void _shoot_vertex_cylinders (mygsl::rng & random_,
                                   geomtools::vector_3d & vertex_);

--- a/source/bxgenvtx/include/genvtx/cylinder_vg.h
+++ b/source/bxgenvtx/include/genvtx/cylinder_vg.h
@@ -102,29 +102,29 @@ namespace genvtx {
     void tree_dump (std::ostream & out_ = std::clog,
                     const std::string & title_ = "",
                     const std::string & indent_ = "",
-                    bool inherit_ = false) const;
+                    bool inherit_ = false) const override;
 
     /// Constructor
     cylinder_vg();
 
     /// Destructor
-    virtual ~cylinder_vg();
+    ~cylinder_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                              ::datatools::service_manager &,
-                             ::genvtx::vg_dict_type &);
+                             ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
   private:
 

--- a/source/bxgenvtx/include/genvtx/from_file_vg.h
+++ b/source/bxgenvtx/include/genvtx/from_file_vg.h
@@ -51,29 +51,29 @@ namespace genvtx {
     from_file_vg();
 
     /// Destructor
-    virtual ~from_file_vg();
+    ~from_file_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                              ::datatools::service_manager &,
-                             ::genvtx::vg_dict_type &);
+                             ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Check if at least one more vertex is available
-    virtual bool has_next_vertex() const;
+    bool has_next_vertex() const override;
 
   protected :
 
     /// Load vertex from the source
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
     /// Load vertex/time from the source
-    virtual void _shoot_vertex_and_time(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_, double & time_);
+    void _shoot_vertex_and_time(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_, double & time_) override;
 
     /// Open the source file
     void _open_source();

--- a/source/bxgenvtx/include/genvtx/i_from_model_vg.h
+++ b/source/bxgenvtx/include/genvtx/i_from_model_vg.h
@@ -44,7 +44,7 @@ namespace genvtx {
     i_from_model_vg();
 
     /// Destructor
-    virtual ~i_from_model_vg();
+    ~i_from_model_vg() override;
 
     /// Check if origin definition is defined
     bool has_origin_def() const;
@@ -74,10 +74,10 @@ namespace genvtx {
     void set_materials_plugin_name(const std::string & mpn_);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// OCD support
     static void ocd_support(datatools::object_configuration_description &, const std::string & label_ = "");

--- a/source/bxgenvtx/include/genvtx/i_vertex_generator.h
+++ b/source/bxgenvtx/include/genvtx/i_vertex_generator.h
@@ -172,7 +172,7 @@ namespace genvtx {
     i_vertex_generator();
 
     /// Destructor
-    virtual ~i_vertex_generator();
+    ~i_vertex_generator() override;
 
     /// Check initialization status
     virtual bool is_initialized() const = 0;
@@ -186,10 +186,10 @@ namespace genvtx {
     virtual void reset() = 0;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// Return the logging priority threshold
     datatools::logger::priority get_logging_priority() const;

--- a/source/bxgenvtx/include/genvtx/in_materials_vertex_validator.h
+++ b/source/bxgenvtx/include/genvtx/in_materials_vertex_validator.h
@@ -34,15 +34,15 @@ namespace genvtx {
                                       datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~in_materials_vertex_validator();
+    ~in_materials_vertex_validator() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties &,
+    void initialize(const datatools::properties &,
                             datatools::service_manager &,
-                            cuts::cut_handle_dict_type &);
+                            cuts::cut_handle_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check reversed flag
     bool is_reversed() const;
@@ -66,15 +66,15 @@ namespace genvtx {
     int get_max_depth() const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   protected :
 
     /// Selection
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxgenvtx/include/genvtx/manager.h
+++ b/source/bxgenvtx/include/genvtx/manager.h
@@ -156,7 +156,7 @@ namespace genvtx {
     manager(datatools::logger::priority p_ = datatools::logger::PRIO_WARNING);
 
     /// Destructor
-    virtual ~manager();
+    ~manager() override;
 
     /// Reset
     void reset();
@@ -200,10 +200,10 @@ namespace genvtx {
     void shoot_vertex_and_time(geomtools::vector_3d & vertex_, double & time_);
 
     /// Smart print method
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
     const genvtx::i_vertex_generator & get(const std::string & vg_name_) const;
 

--- a/source/bxgenvtx/include/genvtx/not_in_daughters_vertex_validator.h
+++ b/source/bxgenvtx/include/genvtx/not_in_daughters_vertex_validator.h
@@ -31,15 +31,15 @@ namespace genvtx {
                                       datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~not_in_daughters_vertex_validator();
+    ~not_in_daughters_vertex_validator() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties &,
+    void initialize(const datatools::properties &,
                             datatools::service_manager &,
-                            cuts::cut_handle_dict_type &);
+                            cuts::cut_handle_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check reversed flag
     bool is_reversed() const;
@@ -54,10 +54,10 @@ namespace genvtx {
     void set_daughter_tolerance(double);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   protected :
 
@@ -68,7 +68,7 @@ namespace genvtx {
      *  - a reference to a logical volume from where the candidate vertex has been shot
      *  - a reference to the candidate vertex expressed in the local reference frame of the logical volume
      */
-    virtual int _accept();
+    int _accept() override;
 
   private:
 

--- a/source/bxgenvtx/include/genvtx/placement_vg.h
+++ b/source/bxgenvtx/include/genvtx/placement_vg.h
@@ -58,26 +58,26 @@ namespace genvtx {
                  const geomtools::placement &);
 
     /// Destructor
-    virtual ~placement_vg();
+    ~placement_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                              ::datatools::service_manager &,
-                             ::genvtx::vg_dict_type &);
+                             ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Check if at least one more vertex is available
-    virtual bool has_next_vertex() const;
+    bool has_next_vertex() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
     void _clear_vg_ ();
 

--- a/source/bxgenvtx/include/genvtx/polycone_model_vg.h
+++ b/source/bxgenvtx/include/genvtx/polycone_model_vg.h
@@ -71,32 +71,32 @@ namespace genvtx {
 
     void set_mode(int);
 
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Constructor
     polycone_model_vg();
 
     /// Destructor
-    virtual ~polycone_model_vg();
+    ~polycone_model_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                             ::datatools::service_manager &,
-                            ::genvtx::vg_dict_type &);
+                            ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
     void _shoot_vertex_polycones(mygsl::rng & random_,
                                  geomtools::vector_3d & vertex_);

--- a/source/bxgenvtx/include/genvtx/polycone_vg.h
+++ b/source/bxgenvtx/include/genvtx/polycone_vg.h
@@ -79,30 +79,30 @@ namespace genvtx {
     void tree_dump(std::ostream & out_ = std::clog,
                    const std::string & title_ = "",
                    const std::string & indent_ = "",
-                   bool inherit_ = false) const;
+                   bool inherit_ = false) const override;
 
 
     /// Constructor
     polycone_vg();
 
     /// Destructor
-    virtual ~polycone_vg();
+    ~polycone_vg() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                              ::datatools::service_manager &,
-                             ::genvtx::vg_dict_type &);
+                             ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
   private:
 

--- a/source/bxgenvtx/include/genvtx/sphere_model_vg.h
+++ b/source/bxgenvtx/include/genvtx/sphere_model_vg.h
@@ -75,32 +75,32 @@ namespace genvtx {
 
     void set_mode (int);
 
-    virtual void tree_dump (std::ostream & out_ = std::clog,
+    void tree_dump (std::ostream & out_ = std::clog,
                             const std::string & title_ = "",
                             const std::string & indent_ = "",
-                            bool inherit_ = false) const;
+                            bool inherit_ = false) const override;
 
     /// Constructor
     sphere_model_vg();
 
     /// Destructor
-    virtual ~sphere_model_vg();
+    ~sphere_model_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                              ::datatools::service_manager &,
-                             ::genvtx::vg_dict_type &);
+                             ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
   private:
 

--- a/source/bxgenvtx/include/genvtx/sphere_vg.h
+++ b/source/bxgenvtx/include/genvtx/sphere_vg.h
@@ -83,29 +83,29 @@ namespace genvtx {
     void tree_dump (std::ostream & out_ = std::clog,
                     const std::string & title_ = "",
                     const std::string & indent_ = "",
-                    bool inherit_ = false) const;
+                    bool inherit_ = false) const override;
 
     /// Constructor
     sphere_vg();
 
     /// Destructor
-    virtual ~sphere_vg();
+    ~sphere_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                              ::datatools::service_manager &,
-                             ::genvtx::vg_dict_type &);
+                             ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
   private:
 

--- a/source/bxgenvtx/include/genvtx/spot_vertex_generator.h
+++ b/source/bxgenvtx/include/genvtx/spot_vertex_generator.h
@@ -46,23 +46,23 @@ namespace genvtx {
     spot_vertex_generator (const geomtools::vector_3d & spot_);
 
     /// Destructor
-    virtual ~spot_vertex_generator();
+    ~spot_vertex_generator() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                              ::datatools::service_manager &,
-                             ::genvtx::vg_dict_type &);
+                             ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
   private:
 

--- a/source/bxgenvtx/include/genvtx/tube_model_vg.h
+++ b/source/bxgenvtx/include/genvtx/tube_model_vg.h
@@ -67,32 +67,32 @@ namespace genvtx {
 
     void set_mode(int);
 
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Constructor
     tube_model_vg();
 
     /// Destructor
-    virtual ~tube_model_vg();
+    ~tube_model_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                             ::datatools::service_manager &,
-                            ::genvtx::vg_dict_type &);
+                            ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
     void _shoot_vertex_tubes(mygsl::rng & random_,
                              geomtools::vector_3d & vertex_);

--- a/source/bxgenvtx/include/genvtx/tube_vg.h
+++ b/source/bxgenvtx/include/genvtx/tube_vg.h
@@ -89,29 +89,29 @@ namespace genvtx {
     void tree_dump (std::ostream & out_ = std::clog,
                     const std::string & title_ = "",
                     const std::string & indent_ = "",
-                    bool inherit_ = false) const;
+                    bool inherit_ = false) const override;
 
     /// Constructor
     tube_vg();
 
     /// Destructor
-    virtual ~tube_vg();
+    ~tube_vg() override;
 
     /// Initialization
-    virtual void initialize(const ::datatools::properties &,
+    void initialize(const ::datatools::properties &,
                              ::datatools::service_manager &,
-                             ::genvtx::vg_dict_type &);
+                             ::genvtx::vg_dict_type &) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
   protected :
 
     /// Randomize vertex
-    virtual void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_);
+    void _shoot_vertex(::mygsl::rng & random_, ::geomtools::vector_3d & vertex_) override;
 
   private:
 

--- a/source/bxgenvtx/include/genvtx/vertex_validation.h
+++ b/source/bxgenvtx/include/genvtx/vertex_validation.h
@@ -143,7 +143,7 @@ namespace genvtx {
     vertex_validation();
 
     /// Destructor
-    virtual ~vertex_validation();
+    ~vertex_validation() override;
 
     /// Set logging priority
     void set_logging_priority(datatools::logger::priority);
@@ -194,7 +194,7 @@ namespace genvtx {
     void tree_dump(std::ostream & out = std::clog,
                    const std::string & title_ = "",
                    const std::string & indent_ = "",
-                   bool inherit_ = false) const;
+                   bool inherit_ = false) const override;
 
     /// Validation
     validate_status_type validate();

--- a/source/bxgeomtools/include/geomtools/angular_range.h
+++ b/source/bxgeomtools/include/geomtools/angular_range.h
@@ -137,10 +137,10 @@ namespace geomtools {
     void reset();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &,
@@ -190,7 +190,7 @@ namespace geomtools {
       void tree_dump(std::ostream & out_ = std::clog,
                      const std::string & title_ = "",
                      const std::string & indent_ = "",
-                     bool inherit_= false) const;
+                     bool inherit_= false) const override;
 
       /// Indirection operator
       /// @return the current sampled angle

--- a/source/bxgeomtools/include/geomtools/base_hit.h
+++ b/source/bxgeomtools/include/geomtools/base_hit.h
@@ -120,7 +120,7 @@ namespace geomtools {
     base_hit() = default;
 
     /// Destructor
-    virtual ~base_hit() = default;
+    ~base_hit() override = default;
 
     /// Copy constructor
     base_hit(const base_hit &) = default;
@@ -148,7 +148,7 @@ namespace geomtools {
     void reset ();
 
     /// Reset the internals of the hit, making it invalid
-    virtual void clear ();
+    void clear () override;
 
     /*  measurement */
 
@@ -171,10 +171,10 @@ namespace geomtools {
     /* interface i_tree_dumpable */
 
     /// \deprecated Smart print
-    virtual void tree_dump (std::ostream & a_out    = std::clog,
+    void tree_dump (std::ostream & a_out    = std::clog,
                             const std::string & a_title  = "",
                             const std::string & a_indent = "",
-                            bool a_inherit          = false) const;
+                            bool a_inherit          = false) const override;
     //!
     //! Supported options:
     //! \code
@@ -208,7 +208,7 @@ namespace geomtools {
       }
 
       /// Functor interface
-      bool operator () (const base_hit & a_hit) const
+      bool operator () (const base_hit & a_hit) const override
       {
         return (a_hit.get_auxiliaries ().has_flag (flag_));
       }
@@ -230,7 +230,7 @@ namespace geomtools {
       }
 
       /// Functor interface
-      bool operator () (const base_hit & a_hit) const
+      bool operator () (const base_hit & a_hit) const override
       {
         return (a_hit.get_auxiliaries ().has_key (key_));
       }
@@ -264,7 +264,7 @@ namespace geomtools {
       }
 
       /// Functor interface
-      bool operator () (const base_hit & a_hit) const
+      bool operator () (const base_hit & a_hit) const override
       {
         if (! a_hit.get_auxiliaries ().has_key (key_)) return false;
         if (! a_hit.get_auxiliaries ().is_string (key_)) return false;
@@ -289,7 +289,7 @@ namespace geomtools {
       }
 
       /// Functor interface
-      bool operator () (const base_hit & a_hit) const
+      bool operator () (const base_hit & a_hit) const override
       {
         return (a_hit.has_hit_id () && a_hit.get_hit_id () == hid_);
       }
@@ -314,7 +314,7 @@ namespace geomtools {
       }
 
       /// Functor interface
-      bool operator () (const base_hit & a_hit) const
+      bool operator () (const base_hit & a_hit) const override
       {
         return (a_hit.has_geom_id () && a_hit.get_geom_id () == gid_);
       }
@@ -339,7 +339,7 @@ namespace geomtools {
       }
 
       /// Functor interface
-      bool operator () (const base_hit & a_hit) const
+      bool operator () (const base_hit & a_hit) const override
       {
         return (! (*pred_)(a_hit));
       }

--- a/source/bxgeomtools/include/geomtools/blur_spot.h
+++ b/source/bxgeomtools/include/geomtools/blur_spot.h
@@ -163,16 +163,16 @@ namespace geomtools {
     const rotation_3d & get_inverse_rotation() const;
 
     /// Destructor
-    virtual ~blur_spot();
+    ~blur_spot() override;
 
     /// Invalidate the object
-    virtual void invalidate();
+    void invalidate() override;
 
     /// Reset internal data
     void reset();
 
     /// Check the validity of the object
-    virtual bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the transverse error of the spot along the X axis
     double get_x_error() const;
@@ -216,14 +216,14 @@ namespace geomtools {
                double nsigma3_or_tolerance_ = DEFAULT_VALUE) const;
 
     /// Generate rendering wires
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_    = std::clog,
+    void tree_dump(std::ostream & out_    = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// Smart print shortcut
     void print() const;

--- a/source/bxgeomtools/include/geomtools/bounding_data.h
+++ b/source/bxgeomtools/include/geomtools/bounding_data.h
@@ -58,7 +58,7 @@ namespace geomtools {
     bounding_data();
 
     /// Destructor
-    virtual ~bounding_data();
+    ~bounding_data() override;
 
     /// Make a bounding box
     void make_box(double xmin_, double xmax_,
@@ -117,16 +117,16 @@ namespace geomtools {
     void build_stackable(stackable_data & stackable_info_) const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & a_out         = std::clog,
+    void tree_dump(std::ostream & a_out         = std::clog,
                            const std::string & a_title  = "",
                            const std::string & a_indent = "",
-                           bool a_inherit               = false) const;
+                           bool a_inherit               = false) const override;
 
     /// Parse enforced bounding data from a properties container
     void parse_bounding_data(const datatools::properties & config_);
 
     /// Generate wires associated to the bounding volume
-    void generate_wires_self(wires_type & wires_, uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_, uint32_t options_ = 0) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/box.h
+++ b/source/bxgeomtools/include/geomtools/box.h
@@ -70,22 +70,22 @@ namespace geomtools {
     };
 
     /// Return the min X coordinates (bounding box)
-    double get_xmin() const;
+    double get_xmin() const override;
 
     /// Return the max X coordinates (bounding box)
-    double get_xmax() const;
+    double get_xmax() const override;
 
     /// Return the min Y coordinates (bounding box)
-    double get_ymin() const;
+    double get_ymin() const override;
 
     /// Return the max Y coordinates (bounding box)
-    double get_ymax() const;
+    double get_ymax() const override;
 
     /// Return the min Z coordinates (bounding box)
-    double get_zmin() const;
+    double get_zmin() const override;
 
     /// Return the max Z coordinates (bounding box)
-    double get_zmax() const;
+    double get_zmax() const override;
 
     /// Return the X dimension
     double get_x() const;
@@ -136,48 +136,48 @@ namespace geomtools {
     box(double a_x, double a_y, double a_z);
 
     /// Destructor
-    virtual ~box();
+    ~box() override;
 
     /// Return the name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     // Check the validity of the object
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Initialize the box from properties
-    virtual void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Return the value of some parameter given by name
     double get_parameter(const std::string &) const;
 
     /// Return the cumulated surface of the box given a list of faces
-    virtual double get_surface(uint32_t a_mask = FACE_ALL) const;
+    double get_surface(uint32_t a_mask = FACE_ALL) const override;
 
     /// Return the volume of the box
-    virtual double get_volume(uint32_t flags_ = 0) const;
+    double get_volume(uint32_t flags_ = 0) const override;
 
     /// Return a collection of face info objects
-    virtual unsigned int compute_faces(face_info_collection_type & faces_) const;
+    unsigned int compute_faces(face_info_collection_type & faces_) const override;
 
     /// Check if a point is inside the box
-    virtual bool is_inside(const vector_3d &,
-                           double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside(const vector_3d &,
+                           double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is inside the box
-    virtual bool is_outside(const vector_3d &,
-                            double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside(const vector_3d &,
+                            double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Print operator
     friend std::ostream & operator<<( std::ostream & , const box & );
@@ -186,16 +186,16 @@ namespace geomtools {
     friend std::istream & operator>>( std::istream & , box & );
 
     /// Find the intercept point of a segment with the box
-    virtual bool find_intercept(const vector_3d & a_from,
+    bool find_intercept(const vector_3d & a_from,
                                 const vector_3d & a_direction,
                                 face_intercept_info & a_intercept,
-                                double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & a_out         = std::clog,
+    void tree_dump(std::ostream & a_out         = std::clog,
                            const std::string & a_title  = "",
                            const std::string & a_indent = "",
-                           bool a_inherit          = false) const;
+                           bool a_inherit          = false) const override;
 
     /// \brief 3D rendering options
     enum box_wires_rendering_option_type {
@@ -215,8 +215,8 @@ namespace geomtools {
     };
 
     /// Generate a list of polylines representing the contour of the shape (for display clients)
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// Compute the positions of the 8 vertexes of the box
     void compute_vertexes(std::vector<vector_3d> & vv_) const;
@@ -238,7 +238,7 @@ namespace geomtools {
     void _set_defaults();
 
     /// Build the bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/circle.h
+++ b/source/bxgeomtools/include/geomtools/circle.h
@@ -38,7 +38,7 @@ namespace geomtools {
     static const std::string & circle_label();
 
     /// Check the validity of the circle
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the radius
     double get_r() const;
@@ -92,7 +92,7 @@ namespace geomtools {
     virtual unsigned int get_number_of_path() const;
 
     /// Return the length of the target paths
-    virtual double get_length(uint32_t flags_ = PATH_ALL_BITS) const;
+    double get_length(uint32_t flags_ = PATH_ALL_BITS) const override;
 
     /// Default constructor
     circle();
@@ -104,32 +104,32 @@ namespace geomtools {
     circle(double radius_, double start_angle_, double delta_angle_);
 
     /// Destructor
-    virtual ~circle();
+    ~circle() override;
 
     /// Return the name of this solid shape class
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & a_out = std::clog,
+    void tree_dump(std::ostream & a_out = std::clog,
                            const std::string & a_title = "",
                            const std::string & a_indent = "",
-                           bool a_inherit= false) const;
+                           bool a_inherit= false) const override;
 
     /// Check if a point is on the curve
-    virtual bool is_on_curve(const vector_3d &,
-                             double a_tolerance = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_curve(const vector_3d &,
+                             double a_tolerance = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Returns the direction of a point on the curve
-    virtual vector_3d get_direction_on_curve(const vector_3d & a_tposition) const;
+    vector_3d get_direction_on_curve(const vector_3d & a_tposition) const override;
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_, uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_, uint32_t options_ = 0) const override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/composite_surface.h
+++ b/source/bxgeomtools/include/geomtools/composite_surface.h
@@ -31,10 +31,10 @@ namespace geomtools {
     static const std::string & composite_surface_label();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the surface is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Default constructor
     composite_surface();
@@ -46,13 +46,13 @@ namespace geomtools {
     composite_surface(double tolerance_, double angular_tolerance_);
 
     /// Destructor
-    virtual ~composite_surface();
+    ~composite_surface() override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Return the number of embedded surfaces
     unsigned int get_number_of_surfaces() const;
@@ -70,44 +70,44 @@ namespace geomtools {
     const face_info & get(unsigned int index_) const;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the perimeter
-    virtual double get_perimeter(uint32_t flags_ = ALL_PIECES) const;
+    double get_perimeter(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Check is a given point belongs to the surface of the 2D shape
     ///
     /// @arg position_ The position to be checked
     /// @arg skin_ The tolerance (effective thickness of the surface)
     /// @return true if the checked position belongs to the surface
-    virtual bool is_on_surface(const vector_3d & position_,
+    bool is_on_surface(const vector_3d & position_,
                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE
-                               ) const;
+                               ) const override;
 
     /// Return the normal direction at some position on the 2D shape's path
     ///
     /// @arg position_ The position to be checked
     /// @return the normal 3D vector at the checked position that is assumes
     ///         belonging to the surface
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = false,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find the intercept point with one of the component face
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/cylinder.h
+++ b/source/bxgeomtools/include/geomtools/cylinder.h
@@ -68,25 +68,25 @@ namespace geomtools {
                            placement & face_placement_) const;
 
     /// Return a collection of face info objects
-    virtual unsigned int compute_faces(face_info_collection_type & faces_) const;
+    unsigned int compute_faces(face_info_collection_type & faces_) const override;
 
     /// Return the min X coordinates (bounding box)
-    double get_xmin () const;
+    double get_xmin () const override;
 
     /// Return the max X coordinates (bounding box)
-    double get_xmax () const;
+    double get_xmax () const override;
 
     /// Return the min Y coordinates (bounding box)
-    double get_ymin () const;
+    double get_ymin () const override;
 
     /// Return the max Y coordinates (bounding box)
-    double get_ymax () const;
+    double get_ymax () const override;
 
     /// Return the min Z coordinates (bounding box)
-    double get_zmin () const;
+    double get_zmin () const override;
 
     /// Return the max Z coordinates (bounding box)
-    double get_zmax () const;
+    double get_zmax () const override;
 
     /// Return the Z dimension
     double get_z () const;
@@ -127,64 +127,64 @@ namespace geomtools {
     cylinder (double a_radius, double a_z);
 
     /// Destructor
-    virtual ~cylinder ();
+    ~cylinder () override;
 
     /// Return the name of the shape
-    virtual std::string get_shape_name () const;
+    std::string get_shape_name () const override;
 
     /// Return a parameter by name
     virtual double get_parameter (const std::string &) const;
 
     /// Check the validity
-    bool is_valid () const;
+    bool is_valid () const override;
 
     /// Initialize
     void init ();
 
     /// Initialize the cylinder from properties
-    virtual void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset the cylinder
-    virtual void reset ();
+    void reset () override;
 
     /// Compute the surface of the cylinder
-    virtual double get_surface (uint32_t a_mask = FACE_ALL) const;
+    double get_surface (uint32_t a_mask = FACE_ALL) const override;
 
     /// Compute the volume of the cylinder
-    virtual double get_volume (uint32_t flags_ = 0) const;
+    double get_volume (uint32_t flags_ = 0) const override;
 
     /// Check if a point is inside the cylinder
-    virtual bool is_inside (const vector_3d &,
-                            double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside (const vector_3d &,
+                            double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the cylinder
-    virtual bool is_outside (const vector_3d &,
-                             double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside (const vector_3d &,
+                             double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept (const vector_3d & a_from,
+    bool find_intercept (const vector_3d & a_from,
                                  const vector_3d & a_direction,
                                  face_intercept_info & a_intercept,
-                                 double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                 double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     friend std::ostream & operator<< (std::ostream &, const cylinder &);
 
     friend std::istream & operator>> (std::istream &, cylinder &);
 
     /// Smart print
-    virtual void tree_dump (std::ostream & a_out         = std::clog,
+    void tree_dump (std::ostream & a_out         = std::clog,
                             const std::string & a_title  = "",
                             const std::string & a_indent = "",
-                            bool a_inherit          = false) const;
+                            bool a_inherit          = false) const override;
 
     /// \brief 3D rendering options
     enum cylinder_wires_rendering_option_type {
@@ -198,8 +198,8 @@ namespace geomtools {
     };
 
     /// Generate a list of polylines representing the contour of the shape (for display clients)
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);
@@ -210,7 +210,7 @@ namespace geomtools {
     void _set_defaults();
 
     /// Build the bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/cylindric_extrusion_boxed_model.h
+++ b/source/bxgeomtools/include/geomtools/cylindric_extrusion_boxed_model.h
@@ -93,16 +93,16 @@ namespace geomtools {
     cylindric_extrusion_boxed_model ();
 
     /// Destructor
-    virtual ~cylindric_extrusion_boxed_model ();
+    ~cylindric_extrusion_boxed_model () override;
 
     /// Return the string Id of the model
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
 
     /// \brief Special wires 3D rendering
@@ -121,20 +121,20 @@ namespace geomtools {
       wires_drawer(const cylindric_extrusion_boxed_model & model_);
 
       //! Destructor
-      virtual ~wires_drawer();
+      ~wires_drawer() override;
 
       //! Generate a list of polylines representing the contour of the shape (for display clients)
-      virtual void generate_wires_self(wires_type & wires_,
-                                       uint32_t options_ = 0) const;
+      void generate_wires_self(wires_type & wires_,
+                                       uint32_t options_ = 0) const override;
 
     };
 
   protected:
 
     /// Executed at construct
-    virtual void _at_construct (const std::string & name_,
+    void _at_construct (const std::string & name_,
                                 const datatools::properties & config_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/cylindrical_sector.h
+++ b/source/bxgeomtools/include/geomtools/cylindrical_sector.h
@@ -29,7 +29,7 @@ namespace geomtools {
     static const std::string & cylindrical_sector_label();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Set the radius
     void set_radius(double new_value_);
@@ -87,40 +87,40 @@ namespace geomtools {
                        double delta_angle_);
 
     /// Destructor
-    virtual ~cylindrical_sector();
+    ~cylindrical_sector() override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Check if the rectangle is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Check if a point is on the surface
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal at a given position of the surface
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = true,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// \brief 3D rendering options
     enum cylsec_wires_rendering_option_type {
@@ -136,8 +136,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/disk.h
+++ b/source/bxgeomtools/include/geomtools/disk.h
@@ -32,7 +32,7 @@ namespace geomtools {
     static const std::string & disk_label();
 
     /// Check if the disk is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Set the outer radius
     void set_outer_r(double);
@@ -89,10 +89,10 @@ namespace geomtools {
     bool has_partial_angle() const;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the perimeter
-    virtual double get_perimeter(uint32_t flags_ = ALL_PIECES) const;
+    double get_perimeter(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the circumference
     double get_circumference() const;
@@ -116,37 +116,37 @@ namespace geomtools {
     disk(double inner_r_, double outer_r_, double start_angle_, double delta_angle_);
 
     /// Destructor
-    virtual ~disk();
+    ~disk() override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if a point is on the surface
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal at a given position of the surface
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = true,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find some intercept point on the surface
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// \brief 3D rendering options
     enum disk_wires_rendering_option_type {
@@ -162,8 +162,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/display_data.h
+++ b/source/bxgeomtools/include/geomtools/display_data.h
@@ -74,7 +74,7 @@ namespace geomtools {
       virtual ~display_item();
       void reset();
       wires_type & grab_wires();
-      DATATOOLS_SERIALIZATION_DECLARATION()
+      DATATOOLS_SERIALIZATION_DECLARATION_NOINHERIT()
     };
 
     typedef std::map<int32_t, display_item> items_dict_type;
@@ -97,7 +97,7 @@ namespace geomtools {
       const display_item & get_framed_item(int frame_index_) const;
       bool has_framed_item(int frame_index_) const;
 
-      DATATOOLS_SERIALIZATION_DECLARATION()
+      DATATOOLS_SERIALIZATION_DECLARATION_NOINHERIT()
     };
 
     typedef std::map<std::string, display_entry> entries_dict_type;

--- a/source/bxgeomtools/include/geomtools/display_data.h
+++ b/source/bxgeomtools/include/geomtools/display_data.h
@@ -108,9 +108,9 @@ namespace geomtools {
     display_data();
 
     /// Destructor
-    virtual ~display_data();
+    ~display_data() override;
 
-    virtual void clear();
+    void clear() override;
 
     const std::vector<std::string> & get_colors() const;
 
@@ -135,10 +135,10 @@ namespace geomtools {
     datatools::properties & grab_auxiliaries();
 
 
-    virtual void tree_dump(std::ostream & a_out         = std::clog,
+    void tree_dump(std::ostream & a_out         = std::clog,
                            const std::string & a_title  = "",
                            const std::string & a_indent = "",
-                           bool a_inherit          = false) const;
+                           bool a_inherit          = false) const override;
 
     display_item & add_static_item(const std::string & name_,
                                    const std::string & group_ = "",

--- a/source/bxgeomtools/include/geomtools/ellipse.h
+++ b/source/bxgeomtools/include/geomtools/ellipse.h
@@ -38,7 +38,7 @@ namespace geomtools {
     static const std::string & ellipse_label();
 
     /// Check the validity of the ellipse
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the X radius
     double get_x_radius() const;
@@ -86,7 +86,7 @@ namespace geomtools {
     virtual unsigned int get_number_of_path() const;
 
     /// Return the length of the target paths
-    virtual double get_length(uint32_t flags_ = PATH_ALL_BITS) const;
+    double get_length(uint32_t flags_ = PATH_ALL_BITS) const override;
 
     /// Check if the ellipse is X oriented
     bool is_x_oriented() const;
@@ -146,33 +146,33 @@ namespace geomtools {
     //                                    double a_tolerance) const;
 
     /// Destructor
-    virtual ~ellipse();
+    ~ellipse() override;
 
     /// Return the name of this solid shape class
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & a_out = std::clog,
+    void tree_dump(std::ostream & a_out = std::clog,
                            const std::string & a_title = "",
                            const std::string & a_indent = "",
-                           bool a_inherit= false) const;
+                           bool a_inherit= false) const override;
 
     /// Check if a point is on the curve (approximative algorithm)
-    virtual bool is_on_curve(const vector_3d &,
-                             double a_tolerance = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_curve(const vector_3d &,
+                             double a_tolerance = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Returns the direction of a point on the curve
-    virtual vector_3d get_direction_on_curve(const vector_3d & a_tposition) const;
+    vector_3d get_direction_on_curve(const vector_3d & a_tposition) const override;
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/ellipsoid.h
+++ b/source/bxgeomtools/include/geomtools/ellipsoid.h
@@ -63,19 +63,19 @@ namespace geomtools {
     void compute_side_face(ellipsoid_sector & face_,
                            placement & face_placement_) const;
 
-    virtual unsigned int compute_faces(face_info_collection_type & faces) const;
+    unsigned int compute_faces(face_info_collection_type & faces) const override;
 
-    double get_xmin() const;
+    double get_xmin() const override;
 
-    double get_xmax() const;
+    double get_xmax() const override;
 
-    double get_ymin() const;
+    double get_ymin() const override;
 
-    double get_ymax() const;
+    double get_ymax() const override;
 
-    double get_zmin() const;
+    double get_zmin() const override;
 
-    double get_zmax() const;
+    double get_zmax() const override;
 
     double get_x_radius() const;
 
@@ -113,52 +113,52 @@ namespace geomtools {
               double zm_, double zp_);
 
     /// Destructor
-    virtual ~ellipsoid();
+    ~ellipsoid() override;
 
     /// Return the name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Return the value of some parameter
     virtual double get_parameter(const std::string &) const;
 
     /// Check the validity of the ellipsoid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Initialize the ellipsoid from properties
-    virtual void initialize(const datatools::properties &,
-                            const handle_dict_type * = 0);
+    void initialize(const datatools::properties &,
+                            const handle_dict_type * = 0) override;
 
     /// Reset the ellipsoid
-    virtual void reset();
+    void reset() override;
 
     /// Compute the surface
-    virtual double get_surface(uint32_t mask_ = FACE_ALL) const;
+    double get_surface(uint32_t mask_ = FACE_ALL) const override;
 
     /// Compute the volume
-    virtual double get_volume(uint32_t flags_ = 0) const;
+    double get_volume(uint32_t flags_ = 0) const override;
 
     /// Check if a point is inside the tube
-    virtual bool is_inside(const vector_3d &,
-                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside(const vector_3d &,
+                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the tube
-    virtual bool is_outside(const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside(const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Find the intercept point with a face of the tube
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     friend std::ostream &
     operator<<(std::ostream &, const ellipsoid &);
@@ -167,10 +167,10 @@ namespace geomtools {
     operator>>(std::istream &, ellipsoid &);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);
@@ -188,8 +188,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 
@@ -197,7 +197,7 @@ namespace geomtools {
     void _set_default();
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/ellipsoid_sector.h
+++ b/source/bxgeomtools/include/geomtools/ellipsoid_sector.h
@@ -43,7 +43,7 @@ namespace geomtools {
     static const std::string & ellipsoid_sector_label();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     double get_x_radius() const;
 
@@ -110,40 +110,40 @@ namespace geomtools {
                      double start_angle_, double delta_angle_);
 
     /// Destructor
-    virtual ~ellipsoid_sector();
+    ~ellipsoid_sector() override;
 
     /// Check the validity of the ellipsoid sector
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset the ellipsoid sector
-    void reset();
+    void reset() override;
 
     /// Return the surface
-    virtual double get_surface(uint32_t mask_ = ALL_PIECES) const;
+    double get_surface(uint32_t mask_ = ALL_PIECES) const override;
 
     /// Check if a point is on the surface
-    virtual bool is_on_surface(const vector_3d & ,
-                               double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d & ,
+                               double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal at a given position of the surface
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = true,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// \brief 3D rendering options
     enum ellsec_wires_rendering_option_type {
@@ -159,8 +159,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/elliptical_cylinder.h
+++ b/source/bxgeomtools/include/geomtools/elliptical_cylinder.h
@@ -69,25 +69,25 @@ namespace geomtools {
                            placement & face_placement_) const;
 
     /// Compute informations about the faces of this solid shape
-    virtual unsigned int compute_faces(face_info_collection_type & faces) const;
+    unsigned int compute_faces(face_info_collection_type & faces) const override;
 
     /// Return the min X coordinates (bounding box)
-    double get_xmin () const;
+    double get_xmin () const override;
 
     /// Return the max X coordinates (bounding box)
-    double get_xmax () const;
+    double get_xmax () const override;
 
     /// Return the min Y coordinates (bounding box)
-    double get_ymin () const;
+    double get_ymin () const override;
 
     /// Return the max Y coordinates (bounding box)
-    double get_ymax () const;
+    double get_ymax () const override;
 
     /// Return the min Z coordinates (bounding box)
-    double get_zmin () const;
+    double get_zmin () const override;
 
     /// Return the max Z coordinates (bounding box)
-    double get_zmax () const;
+    double get_zmax () const override;
 
     /// Return the Z dimension
     double get_z () const;
@@ -123,52 +123,52 @@ namespace geomtools {
     elliptical_cylinder (double xr_, double yr_, double z_);
 
     /// Destructor
-    virtual ~elliptical_cylinder ();
+    ~elliptical_cylinder () override;
 
     /// Return the name of the shape
-    virtual std::string get_shape_name () const;
+    std::string get_shape_name () const override;
 
     /// Return a parameter by name
     virtual double get_parameter (const std::string &) const;
 
     /// Check the validity
-    bool is_valid () const;
+    bool is_valid () const override;
 
     /// Initialize from properties
-    virtual void initialize(const datatools::properties &,
-                            const handle_dict_type *);
+    void initialize(const datatools::properties &,
+                            const handle_dict_type *) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Compute the surface of the cylinder
-    virtual double get_surface (uint32_t mask_ = FACE_ALL) const;
+    double get_surface (uint32_t mask_ = FACE_ALL) const override;
 
     /// Compute the volume of the cylinder
-    virtual double get_volume (uint32_t flags_ = 0) const;
+    double get_volume (uint32_t flags_ = 0) const override;
 
     /// Check if a point is inside the cylinder
-    virtual bool is_inside (const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside (const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the cylinder
-    virtual bool is_outside (const vector_3d &,
-                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside (const vector_3d &,
+                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept (const vector_3d & from_,
+    bool find_intercept (const vector_3d & from_,
                                  const vector_3d & direction_,
                                  face_intercept_info & intercept_,
-                                 double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                 double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     friend std::ostream &
     operator<< (std::ostream &, const elliptical_cylinder &);
@@ -177,10 +177,10 @@ namespace geomtools {
     operator>> (std::istream &, elliptical_cylinder &);
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
     /// \brief 3D rendering options
     enum elliptical_cylinder_wires_rendering_option_type {
@@ -194,8 +194,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);
@@ -206,7 +206,7 @@ namespace geomtools {
     void _set_default();
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/elliptical_cylinder_sector.h
+++ b/source/bxgeomtools/include/geomtools/elliptical_cylinder_sector.h
@@ -44,7 +44,7 @@ namespace geomtools {
     static const std::string & elliptical_cylinder_sector_label();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     double get_x_radius() const;
 
@@ -98,40 +98,40 @@ namespace geomtools {
                                double start_angle_, double delta_angle_);
 
     /// Destructor
-    virtual ~elliptical_cylinder_sector();
+    ~elliptical_cylinder_sector() override;
 
     /// Check the validity of the shape
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset the shape
-    void reset();
+    void reset() override;
 
     /// Return the surface
-    virtual double get_surface(uint32_t mask_ = i_shape_2d::FACE_ALL) const;
+    double get_surface(uint32_t mask_ = i_shape_2d::FACE_ALL) const override;
 
     /// Check if a point is on the surface
-    virtual bool is_on_surface(const vector_3d & ,
-                               double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d & ,
+                               double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal at a given position of the surface
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = true,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// \brief 3D rendering options
     enum ellcylsec_wires_rendering_option_type {
@@ -147,8 +147,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/elliptical_sector.h
+++ b/source/bxgeomtools/include/geomtools/elliptical_sector.h
@@ -35,7 +35,7 @@ namespace geomtools {
     static const std::string & elliptical_sector_label();
 
     /// Check if the elliptical_sector is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the X radius
     double get_x_radius() const;
@@ -77,10 +77,10 @@ namespace geomtools {
     double get_delta_angle() const;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the perimeter
-    virtual double get_perimeter(uint32_t flags_ = ALL_PIECES) const;
+    double get_perimeter(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the circumference
     double get_circumference() const;
@@ -105,37 +105,37 @@ namespace geomtools {
                       double start_angle_, double delta_angle_);
 
     /// Destructor
-    virtual ~elliptical_sector();
+    ~elliptical_sector() override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if a point is on the surface
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal at a given position of the surface
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = true,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find some intercept point on the surface
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// \brief 3D rendering options
     enum elliptical_sector_wires_rendering_option_type {
@@ -149,8 +149,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/extruded_box.h
+++ b/source/bxgeomtools/include/geomtools/extruded_box.h
@@ -79,22 +79,22 @@ namespace geomtools {
     };
 
     /// Return the min X coordinates (bounding box)
-    double get_xmin() const;
+    double get_xmin() const override;
 
     /// Return the max X coordinates (bounding box)
-    double get_xmax() const;
+    double get_xmax() const override;
 
     /// Return the min Y coordinates (bounding box)
-    double get_ymin() const;
+    double get_ymin() const override;
 
     /// Return the max Y coordinates (bounding box)
-    double get_ymax() const;
+    double get_ymax() const override;
 
     /// Return the min Z coordinates (bounding box)
-    double get_zmin() const;
+    double get_zmin() const override;
 
     /// Return the max Z coordinates (bounding box)
-    double get_zmax() const;
+    double get_zmax() const override;
 
     /// Return the X dimension
     double get_x() const;
@@ -176,46 +176,46 @@ namespace geomtools {
                  bool has_top_ = true, bool has_bottom_ = true);
 
     /// Destructor
-    virtual ~extruded_box();
+    ~extruded_box() override;
 
     /// Return the name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     // Check the validity of the object
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Initialize the extruded_box from properties
-    virtual void initialize(const datatools::properties &,
-                            const handle_dict_type *);
+    void initialize(const datatools::properties &,
+                            const handle_dict_type *) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Return the value of some parameter given by name
     double get_parameter(const std::string &) const;
 
     /// Return the cumulated surface of the extruded_box given a list of faces
-    virtual double get_surface(uint32_t mask_ = FACE_ALL) const;
+    double get_surface(uint32_t mask_ = FACE_ALL) const override;
 
     /// Return the volume of the extruded_box
-    virtual double get_volume(uint32_t flags_ = 0) const;
+    double get_volume(uint32_t flags_ = 0) const override;
 
     /// Check if a point is inside the extruded_box
-    virtual bool is_inside(const vector_3d &,
-                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside(const vector_3d &,
+                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is inside the extruded_box
-    virtual bool is_outside(const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside(const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Print operator
     friend std::ostream & operator<<( std::ostream &, const extruded_box & );
@@ -224,19 +224,19 @@ namespace geomtools {
     friend std::istream & operator>>( std::istream &, extruded_box & );
 
     /// Find the intercept point of a segment with the extruded_box
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// Return a collection of face info objects
-    virtual unsigned int compute_faces(face_info_collection_type & faces_) const;
+    unsigned int compute_faces(face_info_collection_type & faces_) const override;
 
     /// Compute the outer box
     void compute_outer_box(box & outer_box_) const;
@@ -259,8 +259,8 @@ namespace geomtools {
     };
 
     /// Generate a list of polylines representing the contour of the shape (for display clients)
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);
@@ -271,7 +271,7 @@ namespace geomtools {
     void _set_default();
 
     /// Build the bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/extruded_box_model.h
+++ b/source/bxgeomtools/include/geomtools/extruded_box_model.h
@@ -53,16 +53,16 @@ namespace geomtools {
     extruded_box_model();
 
     /// Destructor
-    virtual ~extruded_box_model();
+    ~extruded_box_model() override;
 
     /// Return the string Id of the model
-    virtual std::string get_model_id() const;
+    std::string get_model_id() const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
 
     /// Return the embedded extruded box
     const geomtools::extruded_box & get_extruded_box() const;
@@ -75,19 +75,19 @@ namespace geomtools {
       wires_drawer(const extruded_box & eb_);
 
       //! Destructor
-      virtual ~wires_drawer();
+      ~wires_drawer() override;
 
       //! Generate a list of polylines representing the contour of the shape (for display clients)
-      virtual void generate_wires_self(wires_type & wires_,
-                                       uint32_t options_ = 0) const;
+      void generate_wires_self(wires_type & wires_,
+                                       uint32_t options_ = 0) const override;
     };
 
    protected:
 
     /// Executed at construct
-    virtual void _at_construct(const std::string & name_,
+    void _at_construct(const std::string & name_,
                                const datatools::properties & config_,
-                               models_col_type * models_ = 0);
+                               models_col_type * models_ = 0) override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/face_identifier.h
+++ b/source/bxgeomtools/include/geomtools/face_identifier.h
@@ -225,10 +225,10 @@ namespace geomtools {
     friend std::ostream & operator<<(std::ostream & out_, const face_identifier & face_id_);
 
     //! Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/face_info.h
+++ b/source/bxgeomtools/include/geomtools/face_info.h
@@ -43,7 +43,7 @@ namespace geomtools {
     face_info();
 
     //! Destructor
-    ~face_info();
+    ~face_info() override;
 
     //! Check the validity
     bool is_valid() const;
@@ -150,10 +150,10 @@ namespace geomtools {
     void reset();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/geom_id.h
+++ b/source/bxgeomtools/include/geomtools/geom_id.h
@@ -144,7 +144,7 @@ namespace geomtools {
              uint32_t si9_ = INVALID_ADDRESS);
 
     /// Destructor
-    virtual ~geom_id () = default;
+    ~geom_id () override = default;
 
     /// Copy constructor
     geom_id(const geom_id&) = default;

--- a/source/bxgeomtools/include/geomtools/geom_info.h
+++ b/source/bxgeomtools/include/geomtools/geom_info.h
@@ -94,7 +94,7 @@ namespace geomtools {
     {
       return;
     }
-    bool operator () (const geom_info & ginfo_) const
+    bool operator () (const geom_info & ginfo_) const override
     {
       return (ginfo_.get_geom_id ().get_type () == _geom_type_);
     }

--- a/source/bxgeomtools/include/geomtools/geom_map.h
+++ b/source/bxgeomtools/include/geomtools/geom_map.h
@@ -86,13 +86,13 @@ namespace geomtools {
 
     /***  i_locator interface  ***/
 
-    virtual bool validate_id (const geom_id & id_) const;
+    bool validate_id (const geom_id & id_) const override;
 
-    virtual const geom_info & get_geom_info (const geom_id &) const;
+    const geom_info & get_geom_info (const geom_id &) const override;
 
-    virtual const geom_id & get_geom_id (const vector_3d & world_position_,
+    const geom_id & get_geom_id (const vector_3d & world_position_,
                                          int type_,
-                                         double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                         double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     virtual bool has_geom_info (const geom_id &) const;
 

--- a/source/bxgeomtools/include/geomtools/geometry_service.h
+++ b/source/bxgeomtools/include/geomtools/geometry_service.h
@@ -55,14 +55,14 @@ namespace geomtools {
   public:
 
     /// Check initialization flag
-    virtual bool is_initialized () const;
+    bool is_initialized () const override;
 
     /// Initialization
-    virtual int initialize (const datatools::properties & a_config,
-                            datatools::service_dict_type & a_service_dict);
+    int initialize (const datatools::properties & a_config,
+                            datatools::service_dict_type & a_service_dict) override;
 
     /// Termination
-    virtual int reset ();
+    int reset () override;
 
     /// Return a reference to the non mutable geoemtry manager
     const geomtools::manager & get_geom_manager () const;
@@ -71,13 +71,13 @@ namespace geomtools {
     geometry_service ();
 
     /// Destructor
-    virtual ~geometry_service ();
+    ~geometry_service () override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & a_out         = std::clog,
+    void tree_dump (std::ostream & a_out         = std::clog,
                             const std::string & a_title  = "",
                             const std::string & a_indent = "",
-                            bool a_inherit               = false) const;
+                            bool a_inherit               = false) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/grid_model.h
+++ b/source/bxgeomtools/include/geomtools/grid_model.h
@@ -59,7 +59,7 @@ namespace geomtools {
     double get_z () const;
 
     /// Return a reference to the mother box
-    virtual const geomtools::box & get_box () const;
+    const geomtools::box & get_box () const override;
 
     /// Return a reference to the mother box
     const geomtools::box & get_solid () const;
@@ -71,31 +71,31 @@ namespace geomtools {
     grid_model ();
 
     /// Destructor
-    virtual ~grid_model ();
+    ~grid_model () override;
 
     /// Return the model unique class Id
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 
     /// Pre-construction
-    virtual void _pre_construct (datatools::properties & setup_,
-                                 models_col_type * models_);
+    void _pre_construct (datatools::properties & setup_,
+                                 models_col_type * models_) override;
 
     /// Post construction
-    virtual void _post_construct (datatools::properties & setup_,
-                                  models_col_type * models_);
+    void _post_construct (datatools::properties & setup_,
+                                  models_col_type * models_) override;
 
     /// Construction
-    virtual void _at_construct (const std::string & name_,
+    void _at_construct (const std::string & name_,
                                 const datatools::properties & config_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
   private:
 
     const i_model *            _model_; /// Replicated model

--- a/source/bxgeomtools/include/geomtools/helix_3d.h
+++ b/source/bxgeomtools/include/geomtools/helix_3d.h
@@ -47,10 +47,10 @@ namespace geomtools {
     bool is_normal();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the helix is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Invalidate the helix
     void invalidate();
@@ -104,7 +104,7 @@ namespace geomtools {
     double get_angle2() const;
 
     /// Return the length
-    virtual double get_length(uint32_t flags_ = PATH_ALL_BITS) const;
+    double get_length(uint32_t flags_ = PATH_ALL_BITS) const override;
 
     /// Return the curvilinear position from the normalized angle
     double get_curvilinear_position(double t_) const;
@@ -149,16 +149,16 @@ namespace geomtools {
     helix_3d();
 
     /// Destructor
-    virtual ~helix_3d();
+    ~helix_3d() override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
     /// Basic print
     void dump() const;
@@ -188,11 +188,11 @@ namespace geomtools {
                           unsigned int flags_ = 0);
 
     /// Check if a position in on the curve
-    virtual bool is_on_curve(const vector_3d & position_,
-                             double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_curve(const vector_3d & position_,
+                             double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the direction ar some position in on the curve
-    virtual vector_3d get_direction_on_curve(const vector_3d & position_) const;
+    vector_3d get_direction_on_curve(const vector_3d & position_) const override;
 
     /// \brief 3D rendering options
     enum helix_wires_rendering_option_type {
@@ -202,8 +202,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
 
   protected:

--- a/source/bxgeomtools/include/geomtools/i_boxed_model.h
+++ b/source/bxgeomtools/include/geomtools/i_boxed_model.h
@@ -29,7 +29,7 @@ namespace geomtools {
 
     i_boxed_model(const std::string & dummy_ = "");
 
-    virtual ~i_boxed_model();
+    ~i_boxed_model() override;
 
   };
 

--- a/source/bxgeomtools/include/geomtools/i_composite_shape_3d.h
+++ b/source/bxgeomtools/include/geomtools/i_composite_shape_3d.h
@@ -44,7 +44,7 @@ namespace geomtools {
 
       shape_type();
 
-      virtual ~shape_type();
+      ~shape_type() override;
 
       bool is_delete() const;
 
@@ -76,10 +76,10 @@ namespace geomtools {
                               shape_type &);
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_         = std::clog,
+      void tree_dump(std::ostream & out_         = std::clog,
                               const std::string & title_  = "",
                               const std::string & indent_ = "",
-                              bool inherit_          = false) const;
+                              bool inherit_          = false) const override;
 
       /// Print
       void dump(std::ostream & out_ = std::clog) const;
@@ -124,28 +124,28 @@ namespace geomtools {
     };
 
     /// Check if the face identification scheme is based on face bits
-    bool using_face_id_bits() const;
+    bool using_face_id_bits() const override;
 
     /// Check if the face identification scheme uses part index
-    bool using_face_id_part_index() const;
+    bool using_face_id_part_index() const override;
 
     /// Build a face identifier any mask
-    virtual void make_any_face(face_identifier &) const;
+    void make_any_face(face_identifier &) const override;
 
     /// Check if the shape is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Check if the shape is composite
-    bool is_composite() const;
+    bool is_composite() const override;
 
     /// Check if a forced volume can be set
-    virtual bool volume_can_be_forced() const;
+    bool volume_can_be_forced() const override;
 
     /// Constructor
     i_composite_shape_3d(double skin_ = GEOMTOOLS_DEFAULT_TOLERANCE);
 
     /// Destructor
-    virtual ~i_composite_shape_3d();
+    ~i_composite_shape_3d() override;
 
     /// Set first shape
     void set_shape1(i_shape_3d &, const placement &, const std::string & shref_ = "");
@@ -179,17 +179,17 @@ namespace geomtools {
     void dump(std::ostream & out_ = std::clog) const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
     /// Initialize from properties
-    virtual void initialize(const datatools::properties &,
-                            const handle_dict_type *);
+    void initialize(const datatools::properties &,
+                            const handle_dict_type *) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// \brief 3D rendering options
     enum composite_wires_rendering_option_type {

--- a/source/bxgeomtools/include/geomtools/i_locator.h
+++ b/source/bxgeomtools/include/geomtools/i_locator.h
@@ -59,10 +59,10 @@ namespace geomtools {
 
     /// Given a position and the type of some geometry volume, returns if
     /// position is inside and the associated geom_id
-    virtual bool find_geom_id (const vector_3d & position_,
+    bool find_geom_id (const vector_3d & position_,
                                int type_,
                                geom_id & gid_,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
   };
 
@@ -104,10 +104,10 @@ namespace geomtools {
 
     /// Given a position and the type of some geometry volume, returns if
     /// position is inside and the associated geom_id
-    virtual bool find_geom_id (const vector_3d & position_,
+    bool find_geom_id (const vector_3d & position_,
                                int type_,
                                geom_id & gid_,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const = 0;
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override = 0;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/i_model.h
+++ b/source/bxgeomtools/include/geomtools/i_model.h
@@ -86,13 +86,13 @@ namespace geomtools {
     i_model(const std::string & dummy_ = "");
 
     /// Destructor
-    virtual ~i_model();
+    ~i_model() override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
 
     /// Get a non mutable reference to the embedded logical volume
     const geomtools::logical_volume & get_logical() const;

--- a/source/bxgeomtools/include/geomtools/i_object_3d.h
+++ b/source/bxgeomtools/include/geomtools/i_object_3d.h
@@ -190,7 +190,7 @@ namespace geomtools {
     i_object_3d & operator=(const i_object_3d &);
 
     /// Destructor
-    virtual ~i_object_3d();
+    ~i_object_3d() override;
 
     /// Initialize the 3D object
     void initialize_simple();
@@ -202,10 +202,10 @@ namespace geomtools {
     virtual void reset();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);

--- a/source/bxgeomtools/include/geomtools/i_placement.h
+++ b/source/bxgeomtools/include/geomtools/i_placement.h
@@ -49,7 +49,7 @@ namespace geomtools {
     i_placement();
 
     //! Destructor
-    virtual ~i_placement();
+    ~i_placement() override;
 
     //! Check if the placement handles multiple positions
     bool is_multiple() const;
@@ -87,10 +87,10 @@ namespace geomtools {
     void compute_placement(int item_, placement & p_) const;
 
     //! Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
     //! Serialization interface
     DATATOOLS_SERIALIZATION_DECLARATION()

--- a/source/bxgeomtools/include/geomtools/i_shape_1d.h
+++ b/source/bxgeomtools/include/geomtools/i_shape_1d.h
@@ -34,7 +34,7 @@ namespace geomtools {
   public:
 
     /// Return the dimension of the object
-    int get_dimensional() const;
+    int get_dimensional() const override;
 
     /// Check if the 1D shape knows its number of associated paths
     virtual bool has_number_of_paths() const;
@@ -58,7 +58,7 @@ namespace geomtools {
     i_shape_1d(double tolerance_, double angular_tolerance_);
 
     /// Destructor
-    virtual ~i_shape_1d();
+    ~i_shape_1d() override;
 
     /// Check is a given point belongs to the path of the 1D shape
     virtual bool is_on_curve(const vector_3d &,

--- a/source/bxgeomtools/include/geomtools/i_shape_2d.h
+++ b/source/bxgeomtools/include/geomtools/i_shape_2d.h
@@ -71,7 +71,7 @@ namespace geomtools {
     virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
 
     /// Return the dimension of the object
-    int get_dimensional() const;
+    int get_dimensional() const override;
 
     /// Default constructor
     i_shape_2d();
@@ -83,7 +83,7 @@ namespace geomtools {
     i_shape_2d(double tolerance_, double angular_tolerance_);
 
     /// Destructor
-    virtual ~i_shape_2d();
+    ~i_shape_2d() override;
 
     /// Check is a given point belongs to the surface of the 2D shape
     ///

--- a/source/bxgeomtools/include/geomtools/i_shape_3d.h
+++ b/source/bxgeomtools/include/geomtools/i_shape_3d.h
@@ -106,7 +106,7 @@ namespace geomtools {
     void reset_stackable_data();
 
     /// Return the dimension (3)
-    int get_dimensional() const;
+    int get_dimensional() const override;
 
     /// Return the effective skin tolerance associated to the 3D shape
     double get_skin(double a_skin) const;
@@ -133,10 +133,10 @@ namespace geomtools {
     i_shape_3d & operator=(const i_shape_3d &);
 
     /// Destructor
-    virtual ~i_shape_3d();
+    ~i_shape_3d() override;
 
     /// Check if the solid is composite
-    virtual bool is_composite() const;
+    bool is_composite() const override;
 
     /// Check if the face identification scheme is based on face bits
     virtual bool using_face_id_bits() const;
@@ -253,10 +253,10 @@ namespace geomtools {
     void build_default_bounding_data();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & a_out         = std::clog,
+    void tree_dump(std::ostream & a_out         = std::clog,
                            const std::string & a_title  = "",
                            const std::string & a_indent = "",
-                           bool a_inherit               = false) const;
+                           bool a_inherit               = false) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);

--- a/source/bxgeomtools/include/geomtools/i_stackable.h
+++ b/source/bxgeomtools/include/geomtools/i_stackable.h
@@ -168,7 +168,7 @@ namespace geomtools {
     stackable_data();
 
     /// Destructor
-    virtual ~stackable_data();
+    ~stackable_data() override;
 
     bool check(const stackable::stackability_mode flags_ = stackable::STACKABILITY_STRONG) const;
 
@@ -197,28 +197,28 @@ namespace geomtools {
     void invalidate();
 
     /// Return the minimum X
-    virtual double get_xmin() const;
+    double get_xmin() const override;
 
     /// Return the maximum X
-    virtual double get_xmax() const;
+    double get_xmax() const override;
 
     /// Return the minimum Y
-    virtual double get_ymin() const;
+    double get_ymin() const override;
 
     /// Return the maximum Y
-    virtual double get_ymax() const;
+    double get_ymax() const override;
 
     /// Return the minimum Z
-    virtual double get_zmin() const;
+    double get_zmin() const override;
 
     /// Return the maximum Z
-    virtual double get_zmax() const;
+    double get_zmax() const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
 
     /// Print
     void dump(std::ostream & out_ = std::clog) const;

--- a/source/bxgeomtools/include/geomtools/i_wires_drawer.h
+++ b/source/bxgeomtools/include/geomtools/i_wires_drawer.h
@@ -94,7 +94,7 @@ namespace geomtools {
     }
 
     //! Destructor
-    virtual ~i_wires_drawer()
+    ~i_wires_drawer() override
     {
       return;
     }

--- a/source/bxgeomtools/include/geomtools/id_mgr.h
+++ b/source/bxgeomtools/include/geomtools/id_mgr.h
@@ -143,7 +143,7 @@ namespace geomtools {
       category_info();
 
       /// Destructor
-      virtual ~category_info();
+      ~category_info() override;
 
       /// Returns the size of the list of addresses
       size_t get_depth() const;
@@ -169,8 +169,8 @@ namespace geomtools {
       //!   "full_categories" : true
       //! }
       //! \endcode
-      virtual void print_tree(std::ostream & out_ = std::clog,
-                              const boost::property_tree::ptree & options_ = datatools::i_tree_dumpable::empty_options()) const;
+      void print_tree(std::ostream & out_ = std::clog,
+                              const boost::property_tree::ptree & options_ = datatools::i_tree_dumpable::empty_options()) const override;
 
       /// Check lock status
       bool is_locked() const;
@@ -215,7 +215,7 @@ namespace geomtools {
     id_mgr();
 
     /// Destructor
-    virtual ~id_mgr();
+    ~id_mgr() override;
 
     void set_force_world(bool);
 
@@ -250,8 +250,8 @@ namespace geomtools {
     //                        bool inherit_               = false) const;
 
     /// Smart print
-    virtual void print_tree(std::ostream & out_ = std::clog,
-                            const boost::property_tree::ptree & options_ = datatools::i_tree_dumpable::empty_options()) const;
+    void print_tree(std::ostream & out_ = std::clog,
+                            const boost::property_tree::ptree & options_ = datatools::i_tree_dumpable::empty_options()) const override;
 
     /// Check if some category's description exists for a given type
     bool has_category_info(int type_) const;

--- a/source/bxgeomtools/include/geomtools/intersection_3d.h
+++ b/source/bxgeomtools/include/geomtools/intersection_3d.h
@@ -30,45 +30,45 @@ namespace geomtools {
     static const std::string & intersection_3d_label();
 
     /// Return the name of the shape type
-    std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Default constructor
     intersection_3d();
 
     /// Destructor
-    virtual ~intersection_3d();
+    ~intersection_3d() override;
 
     /// Check if a point is inside the cylinder
-    virtual bool is_inside(const vector_3d & position_,
-                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside(const vector_3d & position_,
+                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the cylinder
-    virtual bool is_outside(const vector_3d & position_,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside(const vector_3d & position_,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_invalid(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept (const vector_3d & from_,
+    bool find_intercept (const vector_3d & from_,
                                  const vector_3d & direction_,
                                  face_intercept_info & intercept_,
-                                 double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                 double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
     // Registration interface :
     GEOMTOOLS_OBJECT_3D_REGISTRATION_INTERFACE(intersection_3d)

--- a/source/bxgeomtools/include/geomtools/line_3d.h
+++ b/source/bxgeomtools/include/geomtools/line_3d.h
@@ -47,10 +47,10 @@ namespace geomtools {
     bool is_normal();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the line is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Invalidate the line
     void invalidate();
@@ -77,7 +77,7 @@ namespace geomtools {
     vector_3d get_point(double t_) const;
 
     /// Return the length of the linear segment
-    virtual double get_length(uint32_t flags_ = PATH_ALL_BITS) const;
+    double get_length(uint32_t flags_ = PATH_ALL_BITS) const override;
 
     /// Default constructor
     line_3d();
@@ -94,13 +94,13 @@ namespace geomtools {
     line_3d(const segment_type & segment_);
 
     /// Destructor
-    virtual ~line_3d();
+    ~line_3d() override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// Print approximated data (x,y,z) triplets representing the line
     static void print_xyz(std::ostream & out_, const line_3d & line_);
@@ -161,11 +161,11 @@ namespace geomtools {
                        double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
 
     /// Check if a position is on the line segment
-    virtual bool is_on_curve(const vector_3d & position_,
-                             double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_curve(const vector_3d & position_,
+                             double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the direction at some position in on the line
-    virtual vector_3d get_direction_on_curve(const vector_3d & position_) const;
+    vector_3d get_direction_on_curve(const vector_3d & position_) const override;
 
     /// Compute a collection of vertexes representing the line
     void make_vertex_collection(polyline_type &) const;
@@ -174,8 +174,8 @@ namespace geomtools {
     polyline_type make_vertex_collection() const;
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/logical_volume.h
+++ b/source/bxgeomtools/include/geomtools/logical_volume.h
@@ -138,13 +138,13 @@ namespace geomtools {
     logical_volume (const std::string &, const i_shape_3d *);
 
     /// Desctructor
-    virtual ~logical_volume ();
+    ~logical_volume () override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
     bool has_physical (const std::string & name_) const;
 

--- a/source/bxgeomtools/include/geomtools/manager.h
+++ b/source/bxgeomtools/include/geomtools/manager.h
@@ -197,7 +197,7 @@ namespace geomtools {
       plugin_entry();
 
       /// Destructor
-      ~plugin_entry();
+      ~plugin_entry() override;
 
       /// Return a reference to the mutable plugin
       base_plugin & grab();
@@ -206,10 +206,10 @@ namespace geomtools {
       const base_plugin & get() const;
 
       /// Smart print
-      virtual void tree_dump(std::ostream &      out_ = std::clog,
+      void tree_dump(std::ostream &      out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool                inherit_ = false) const;
+                             bool                inherit_ = false) const override;
 
     protected:
 
@@ -370,7 +370,7 @@ namespace geomtools {
     manager();
 
     /// Destructor
-    virtual ~manager();
+    ~manager() override;
 
     /// Initialize the geometry manager from a container of properties
     void init(const datatools::properties & config_);
@@ -382,10 +382,10 @@ namespace geomtools {
     void reset();
 
     /// Smart print
-    virtual void tree_dump(std::ostream &      out_ = std::clog,
+    void tree_dump(std::ostream &      out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool                inherit_ = false) const;
+                           bool                inherit_ = false) const override;
 
     //! Return a reference to the plugin factory register
     const base_plugin::factory_register_type & get_plugins_factory_register();

--- a/source/bxgeomtools/include/geomtools/mapping.h
+++ b/source/bxgeomtools/include/geomtools/mapping.h
@@ -121,14 +121,14 @@ namespace geomtools {
     mapping ();
 
     //! Destructor
-    virtual ~mapping ();
+    ~mapping () override;
 
     //! Configure the mapping
     void initialize (const datatools::properties & config_);
 
     //! Build the mapping information
-    virtual void build_from (const model_factory & factory_,
-                             const std::string & mother_ = "world");
+    void build_from (const model_factory & factory_,
+                             const std::string & mother_ = "world") override;
 
     //! Basic print of the embedded mapping dictionary
     void dump_dictionnary (std::ostream & out_ = std::clog) const;

--- a/source/bxgeomtools/include/geomtools/mapping_plugin.h
+++ b/source/bxgeomtools/include/geomtools/mapping_plugin.h
@@ -32,18 +32,18 @@ namespace geomtools {
     mapping_plugin ();
 
     /// Destructor
-    virtual ~mapping_plugin ();
+    ~mapping_plugin () override;
 
     /// Main plugin initialization method
-    virtual int initialize(const datatools::properties & config_,
+    int initialize(const datatools::properties & config_,
                            const geomtools::manager::plugins_dict_type & plugins_,
-                           const datatools::service_dict_type & services_);
+                           const datatools::service_dict_type & services_) override;
 
     /// Plugin reset method
-    virtual int reset();
+    int reset() override;
 
     /// Check if plugin is initialized
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Returns a non-mutable reference to the embeded mapping instance
     const geomtools::mapping & get_mapping () const;

--- a/source/bxgeomtools/include/geomtools/materials_plugin.h
+++ b/source/bxgeomtools/include/geomtools/materials_plugin.h
@@ -45,18 +45,18 @@ namespace geomtools {
     materials_plugin ();
 
     /// Destructor
-    virtual ~materials_plugin ();
+    ~materials_plugin () override;
 
     /// Main initialization method
-    virtual int initialize(const datatools::properties & config_,
+    int initialize(const datatools::properties & config_,
                            const geomtools::manager::plugins_dict_type & plugins_,
-                           const datatools::service_dict_type & services_);
+                           const datatools::service_dict_type & services_) override;
 
     /// Main reset method
-    virtual int reset();
+    int reset() override;
 
     /// Check if plugin is initialized
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Return a non-mutable reference on a manager of isotopes, elements and materials
     const materials::manager & get_manager () const;

--- a/source/bxgeomtools/include/geomtools/model_factory.h
+++ b/source/bxgeomtools/include/geomtools/model_factory.h
@@ -84,7 +84,7 @@ namespace geomtools {
     model_factory(bool debug_, bool core_factory_verbose_ = false);
 
     /// Destructor
-    virtual ~model_factory();
+    ~model_factory() override;
 
     /// Load a geometry models definition file
     void load(const std::string & mprop_file_);
@@ -108,10 +108,10 @@ namespace geomtools {
     const std::vector<std::string> & get_property_prefixes() const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// Check if an external shape factory is referenced
     bool has_shape_factory() const;

--- a/source/bxgeomtools/include/geomtools/model_with_internal_mesh_tools.h
+++ b/source/bxgeomtools/include/geomtools/model_with_internal_mesh_tools.h
@@ -138,7 +138,7 @@ namespace geomtools {
     model_with_internal_mesh_data();
 
     /// Destructor
-    ~model_with_internal_mesh_data();
+    ~model_with_internal_mesh_data() override;
 
     /// Set the logging priprity threshold
     void set_logging(datatools::logger::priority);
@@ -188,10 +188,10 @@ namespace geomtools {
                          const std::string & prefix_ = "");
     */
 
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/multiple_items_model.h
+++ b/source/bxgeomtools/include/geomtools/multiple_items_model.h
@@ -39,7 +39,7 @@ namespace geomtools {
 
     const MWIM & get_internals () const;
 
-    virtual const geomtools::box & get_box () const;
+    const geomtools::box & get_box () const override;
 
     const box & get_solid () const;
 
@@ -47,26 +47,26 @@ namespace geomtools {
 
     void set_material_name (const std::string &);
 
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
     /// Default constructor
     multiple_items_model ();
 
     /// Destructor
-    virtual ~multiple_items_model ();
+    ~multiple_items_model () override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 
     /// Construction
-    virtual void _at_construct (const std::string & label_,
+    void _at_construct (const std::string & label_,
                                 const datatools::properties & config_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/multiple_placement.h
+++ b/source/bxgeomtools/include/geomtools/multiple_placement.h
@@ -43,31 +43,31 @@ namespace geomtools {
 
     placement & get_placement(int index_);
 
-    virtual size_t get_dimension() const;
+    size_t get_dimension() const override;
 
-    virtual bool is_replica() const;
+    bool is_replica() const override;
 
-    virtual size_t get_number_of_items() const;
+    size_t get_number_of_items() const override;
 
-    virtual void get_placement(int item_, placement & p_) const;
+    void get_placement(int item_, placement & p_) const override;
 
-    virtual size_t compute_index_map(std::vector<uint32_t> & map_,
-                                     int item_) const;
+    size_t compute_index_map(std::vector<uint32_t> & map_,
+                                     int item_) const override;
 
     /// Default constructor
     multiple_placement();
 
     /// Destructor
-    virtual ~multiple_placement();
+    ~multiple_placement() override;
 
     /// Reset
     virtual void reset();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "geomutils::multiple_placement",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/physical_volume.h
+++ b/source/bxgeomtools/include/geomtools/physical_volume.h
@@ -109,16 +109,16 @@ namespace geomtools {
                     const i_placement    * placement_,
                     datatools::logger::priority = datatools::logger::PRIO_FATAL);
 
-    virtual ~physical_volume();
+    ~physical_volume() override;
 
     void set_logging_priority(datatools::logger::priority);
 
     datatools::logger::priority get_logging_priority() const;
 
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
   private:
 
     void _init_defaults_();

--- a/source/bxgeomtools/include/geomtools/placement.h
+++ b/source/bxgeomtools/include/geomtools/placement.h
@@ -214,23 +214,23 @@ namespace geomtools {
     // geomtools::i_placement interface:
 
     /// Return the dimension of the(multi-)placement object
-    virtual size_t get_dimension() const;
+    size_t get_dimension() const override;
 
     /// Return the number of placement entries associated to this placement object
-    virtual size_t get_number_of_items() const;
+    size_t get_number_of_items() const override;
 
     /// Compute the placement at given index
-    virtual void get_placement(int item_, placement & p_) const;
+    void get_placement(int item_, placement & p_) const override;
 
     /// Check if placement is a replica
-    virtual bool is_replica() const;
+    bool is_replica() const override;
 
     /// Check if the (multi-)placement has only one rotation for all its placement objects
-    virtual bool has_only_one_rotation() const;
+    bool has_only_one_rotation() const override;
 
     /// Compute the list of multi-dimension multiplet for placement at given index
-    virtual size_t compute_index_map(std::vector<uint32_t> & map_,
-                                     int item_) const;
+    size_t compute_index_map(std::vector<uint32_t> & map_,
+                                     int item_) const override;
 
     /// Check if the placement is identity
     bool is_identity() const;
@@ -342,7 +342,7 @@ namespace geomtools {
               const rotation_3d & rotation_);
 
     /// Destructor
-    virtual ~placement();
+    ~placement() override;
 
     /// Reset
     virtual void reset();
@@ -385,10 +385,10 @@ namespace geomtools {
     void initialize(const datatools::properties & config_, uint32_t flags_ = 0);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_  = std::clog,
+    void tree_dump(std::ostream & out_  = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// Basic print
     void dump(std::ostream      & out_    = std::clog,

--- a/source/bxgeomtools/include/geomtools/plane.h
+++ b/source/bxgeomtools/include/geomtools/plane.h
@@ -31,13 +31,13 @@ namespace geomtools {
     static const std::string & plane_label();
 
     /// Check if the plane is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset the shape
-    void reset();
+    void reset() override;
 
     /// Return the first parameter
     double a() const;
@@ -90,26 +90,26 @@ namespace geomtools {
     geomtools::vector_3d projection(const geomtools::vector_3d & position_,
                                     const geomtools::vector_3d & direction_) const;
 
-    virtual bool is_on_surface(const geomtools::vector_3d & position_,
-                               double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const geomtools::vector_3d & position_,
+                               double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
-    virtual geomtools::vector_3d
+    geomtools::vector_3d
     get_normal_on_surface(const geomtools::vector_3d & position_,
                           bool check_ = true,
-                          double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                          double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
-    virtual bool find_intercept(const geomtools::vector_3d & from_,
+    bool find_intercept(const geomtools::vector_3d & from_,
                                 const geomtools::vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     void print_grid(std::ostream & out_, double padding_ = 1.0, int n1_ = 3, int n2_ = 3) const;
 
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/plate_with_hole_model.h
+++ b/source/bxgeomtools/include/geomtools/plate_with_hole_model.h
@@ -55,19 +55,19 @@ namespace geomtools {
     const geomtools::subtraction_3d & get_solid () const;
 
     /// Return the geometry model class Id
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
     /// Default constructor
     plate_with_hole_model ();
 
     /// Destructor
-    virtual ~plate_with_hole_model ();
+    ~plate_with_hole_model () override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
     /// \brief Special wires 3D rendering
     struct wires_drawer : public i_wires_drawer<plate_with_hole_model>
@@ -85,20 +85,20 @@ namespace geomtools {
       wires_drawer(const plate_with_hole_model & model_);
 
       //! Destructor
-      virtual ~wires_drawer();
+      ~wires_drawer() override;
 
       //! Generate a list of polylines representing the contour of the shape (for display clients)
-      virtual void generate_wires_self(wires_type & wires_,
-                                       uint32_t options_ = 0) const;
+      void generate_wires_self(wires_type & wires_,
+                                       uint32_t options_ = 0) const override;
 
     };
 
   protected:
 
     /// Construction
-    virtual void _at_construct(const std::string & name_,
+    void _at_construct(const std::string & name_,
                                const datatools::properties & setup_,
-                               geomtools::models_col_type * models_ = 0);
+                               geomtools::models_col_type * models_ = 0) override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/polycone.h
+++ b/source/bxgeomtools/include/geomtools/polycone.h
@@ -90,22 +90,22 @@ namespace geomtools {
     bool is_extruded () const;
 
     /// Return the X min
-    double get_xmin () const;
+    double get_xmin () const override;
 
     /// Return the X max
-    double get_xmax () const;
+    double get_xmax () const override;
 
     /// Return the Y min
-    double get_ymin () const;
+    double get_ymin () const override;
 
     /// Return the Y max
-    double get_ymax () const;
+    double get_ymax () const override;
 
     /// Return the Z min
-    double get_zmin () const;
+    double get_zmin () const override;
 
     /// Return the Z max
-    double get_zmax () const;
+    double get_zmax () const override;
 
     /// Return the Z dimension
     double get_z () const;
@@ -144,13 +144,13 @@ namespace geomtools {
     polycone ();
 
     //! Destructor
-    virtual ~polycone ();
+    ~polycone () override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the solid is valid
-    bool is_valid () const;
+    bool is_valid () const override;
 
     /// Add a new point with only Rmax
     void add(double z_, double rmax_, bool compute_ = true);
@@ -206,10 +206,10 @@ namespace geomtools {
                      int mode_ = RMIN_RMAX);
 
     /// Main initialization method from a container of configuration parameters
-    virtual void initialize (const datatools::properties & setup_, const handle_dict_type * = 0);
+    void initialize (const datatools::properties & setup_, const handle_dict_type * = 0) override;
 
     /// Reset/invalidate the solid
-    virtual void reset ();
+    void reset () override;
 
     /// Check for a top face
     bool has_top_face() const;
@@ -260,7 +260,7 @@ namespace geomtools {
     void compute_stop_angle_face(composite_surface & face_, placement &) const;
 
     /// Compute informations about the faces of this solid shape
-    virtual unsigned int compute_faces(face_info_collection_type &) const;
+    unsigned int compute_faces(face_info_collection_type &) const override;
 
     /// Compute the inner polycone
     void compute_inner_polycone (polycone & ip_);
@@ -269,10 +269,10 @@ namespace geomtools {
     void compute_outer_polycone (polycone & op_);
 
     /// Compute the volume
-    virtual double get_volume (uint32_t flags_ = 0) const;
+    double get_volume (uint32_t flags_ = 0) const override;
 
     /// Compute the surface
-    virtual double get_surface (uint32_t mask_ = FACE_ALL) const;
+    double get_surface (uint32_t mask_ = FACE_ALL) const override;
 
     /// Return the min Z
     double get_z_min () const;
@@ -287,33 +287,33 @@ namespace geomtools {
     double get_parameter ( const std::string & flag_ ) const;
 
     /// Check if a point is inside the frustrum
-    virtual bool is_inside (const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside (const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the frustrum
-    virtual bool is_outside (const vector_3d &,
-                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside (const vector_3d &,
+                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Compute the normal to the surface of the furstrum
-    virtual vector_3d get_normal_on_surface (const vector_3d & position_,
-                                             const face_identifier & ) const;
+    vector_3d get_normal_on_surface (const vector_3d & position_,
+                                             const face_identifier & ) const override;
 
     /// Find the intercept point with a face of the frustrum
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     // Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
     friend std::ostream & operator<< (std::ostream &, const polycone &);
 
@@ -337,18 +337,18 @@ namespace geomtools {
     };
 
     /// Generate a list of polylines representing the contour of the shape (for display clients)
-    virtual void generate_wires_self(wires_type & wires_, uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_, uint32_t options_ = 0) const override;
 
   protected:
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
     /// Set default attributes
     void _set_defaults();
 
     /// Executed at lock stage
-    virtual void _at_lock();
+    void _at_lock() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/polyhedra.h
+++ b/source/bxgeomtools/include/geomtools/polyhedra.h
@@ -104,22 +104,22 @@ namespace geomtools {
     bool is_extruded () const;
 
     /// Return the X min
-    double get_xmin () const;
+    double get_xmin () const override;
 
     /// Return the X max
-    double get_xmax () const;
+    double get_xmax () const override;
 
     /// Return the Y min
-    double get_ymin () const;
+    double get_ymin () const override;
 
     /// Return the Y max
-    double get_ymax () const;
+    double get_ymax () const override;
 
     /// Return the Z min
-    double get_zmin () const;
+    double get_zmin () const override;
 
     /// Return the Z max
-    double get_zmax () const;
+    double get_zmax () const override;
 
     /// Return the R max
     double get_r_max () const;
@@ -148,13 +148,13 @@ namespace geomtools {
     polyhedra ();
 
     //! Destructor
-    virtual ~polyhedra ();
+    ~polyhedra () override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name () const;
+    std::string get_shape_name () const override;
 
     /// Check if the solid is valid
-    bool is_valid () const;
+    bool is_valid () const override;
 
     /// Add a new point with only Rmax
     void add (double z_, double rmax_, bool compute_ = true);
@@ -163,10 +163,10 @@ namespace geomtools {
     void add (double z_, double rmin_, double rmax_, bool compute_ = true);
 
     /// Main initialization method from a container of configuration parameters
-    virtual void initialize (const datatools::properties & setup_, const handle_dict_type * = 0);
+    void initialize (const datatools::properties & setup_, const handle_dict_type * = 0) override;
 
    /// Reset/invalidate the solid
-    virtual void reset ();
+    void reset () override;
 
     /// Initialize from a file
     void initialize (const std::string & filename_, int mode_ = RMIN_RMAX);
@@ -205,7 +205,7 @@ namespace geomtools {
     void compute_outer_face(composite_surface & in_, placement &) const;
 
     /// Compute informations about the faces of this solid shape
-    virtual unsigned int compute_faces(face_info_collection_type &) const;
+    unsigned int compute_faces(face_info_collection_type &) const override;
 
     /// Compute the inner polyhedra
     void compute_inner_polyhedra (polyhedra & ip_);
@@ -214,10 +214,10 @@ namespace geomtools {
     void compute_outer_polyhedra (polyhedra & op_);
 
     /// Compute the volume
-    virtual double get_volume (uint32_t flags_ = 0) const;
+    double get_volume (uint32_t flags_ = 0) const override;
 
     /// Compute the surface
-    virtual double get_surface (uint32_t mask_ = FACE_ALL) const;
+    double get_surface (uint32_t mask_ = FACE_ALL) const override;
 
     /// Return the min Z
     double get_z_min () const;
@@ -232,33 +232,33 @@ namespace geomtools {
     double get_parameter ( const std::string & flag_ ) const;
 
     /// Check if a point is inside the frustrum
-    virtual bool is_inside (const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside (const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the frustrum
-    virtual bool is_outside (const vector_3d &,
-                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside (const vector_3d &,
+                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Compute the normal to the surface of the furstrum
-    virtual vector_3d get_normal_on_surface (const vector_3d & position_,
-                                             const face_identifier & ) const;
+    vector_3d get_normal_on_surface (const vector_3d & position_,
+                                             const face_identifier & ) const override;
 
     /// Find the intercept point with a face of the frustrum
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
     /// \brief 3D rendering options
     enum polyhedra_wires_rendering_option_type {
@@ -279,8 +279,8 @@ namespace geomtools {
     };
 
     /// Generate a list of polylines representing the contour of the shape (for display clients)
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     friend std::ostream & operator<< (std::ostream &, const polyhedra &);
 
@@ -289,13 +289,13 @@ namespace geomtools {
   protected:
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
     /// Set default attributes
     void _set_defaults();
 
     /// Executed at lock stage
-    virtual void _at_lock();
+    void _at_lock() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/polyline_3d.h
+++ b/source/bxgeomtools/include/geomtools/polyline_3d.h
@@ -42,10 +42,10 @@ namespace geomtools {
     typedef polyline_type point_col;
 
     /// Return the name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the polyline is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Check if the polyline is closed
     bool is_closed() const;
@@ -63,7 +63,7 @@ namespace geomtools {
     polyline_3d(bool closed_);
 
     /// Destructor
-    virtual ~polyline_3d();
+    ~polyline_3d() override;
 
     /// Remove all points
     void clear();
@@ -87,7 +87,7 @@ namespace geomtools {
     const vector_3d & get_vertex(int i_) const;
 
     /// Return the length of the linear segment
-    virtual double get_length(uint32_t flags_ = PATH_ALL_BITS) const;
+    double get_length(uint32_t flags_ = PATH_ALL_BITS) const override;
 
     // inefficient algorithm:
     void make_vertex_collection(basic_polyline_3d &) const;
@@ -96,11 +96,11 @@ namespace geomtools {
     polyline_type make_vertex_collection() const;
 
     /// Check if a point belongs to the polyline
-    virtual bool is_on_curve(const vector_3d & position_,
-                             double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_curve(const vector_3d & position_,
+                             double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the direction at some position along the polyline
-    virtual vector_3d get_direction_on_curve(const vector_3d & position_) const;
+    vector_3d get_direction_on_curve(const vector_3d & position_) const override;
 
     /// Return a non mutable reference to the collection of points
     const polyline_type & get_points() const;
@@ -109,14 +109,14 @@ namespace geomtools {
     polyline_type & grab_points();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/quadrangle.h
+++ b/source/bxgeomtools/include/geomtools/quadrangle.h
@@ -43,13 +43,13 @@ namespace geomtools {
     static const std::string & quadrangle_label();
 
     /// Check the validity of the quadrangle
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the perimeter
-    virtual double get_perimeter(uint32_t flags_ = ALL_PIECES) const;
+    double get_perimeter(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Check the alignment of 4 points candidate to make a quadrangle
     static bool check_vertexes(const geomtools::vector_3d & v0_,
@@ -98,37 +98,37 @@ namespace geomtools {
     quadrangle(const vector_3d & p0_, const vector_3d & p1_, const vector_3d & p2_, const vector_3d & p3_);
 
     /// Destructor
-    virtual ~quadrangle();
+    ~quadrangle() override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check is a given point belongs to the surface of the 2D shape
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal direction at some position on the 2D shape's path
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = false,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find the intercept of a ray with the 2D shape's surfaces
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// \brief Index of an inner triangle
     enum inner_triangle_index_type {
@@ -170,11 +170,11 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// Build an ordered collection of vertexes
-    virtual unsigned int compute_vertexes(vertex_col_type & vertexes_) const;
+    unsigned int compute_vertexes(vertex_col_type & vertexes_) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/quadric.h
+++ b/source/bxgeomtools/include/geomtools/quadric.h
@@ -36,16 +36,16 @@ namespace geomtools {
     static const std::string & quadric_label();
 
     //! Return the shape name
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     //! Check if the plane is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     //! Reset
-    void reset();
+    void reset() override;
 
     //! Default constructor
     quadric();
@@ -108,18 +108,18 @@ namespace geomtools {
                                     double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
 
     //! Check if the point
-    virtual bool is_on_surface(const geomtools::vector_3d & position_,
-                               double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const geomtools::vector_3d & position_,
+                               double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
-    virtual geomtools::vector_3d
+    geomtools::vector_3d
     get_normal_on_surface(const geomtools::vector_3d & position_,
                           bool check_ = true,
-                          double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                          double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
-    virtual bool find_intercept(const geomtools::vector_3d & from_,
+    bool find_intercept(const geomtools::vector_3d & from_,
                                 const geomtools::vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     //! Make a general plane
     //! f(x,y,z) = ax + by + cz + d = 0
@@ -206,13 +206,13 @@ namespace geomtools {
     static void make_parabolic_cylinder_along_z(quadric & q_, double a_);
 
     //!
-    void generate_wires_self(wires_type &, uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type &, uint32_t options_ = 0) const override;
 
     //! Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/rectangle.h
+++ b/source/bxgeomtools/include/geomtools/rectangle.h
@@ -37,7 +37,7 @@ namespace geomtools {
     static const std::string & rectangle_label();
 
     /// Check if the rectangle is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the X dimension
     double get_x() const;
@@ -55,10 +55,10 @@ namespace geomtools {
     void set(double x_, double y_);
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the perimeter
-    virtual double get_perimeter(uint32_t flags_ = ALL_PIECES) const;
+    double get_perimeter(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the circumference
     double get_circumference() const;
@@ -73,28 +73,28 @@ namespace geomtools {
     rectangle(double x_, double y_);
 
     /// Destructor
-    virtual ~rectangle();
+    ~rectangle() override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = true,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// \brief 3D rendering options
     enum rectangle_wires_rendering_option_type {
@@ -110,17 +110,17 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// Build an ordered collection of vertexes
-    virtual unsigned int compute_vertexes(vertex_col_type & vertexes_) const;
+    unsigned int compute_vertexes(vertex_col_type & vertexes_) const override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/regular_3d_mesh_placement.h
+++ b/source/bxgeomtools/include/geomtools/regular_3d_mesh_placement.h
@@ -98,24 +98,24 @@ namespace geomtools {
 
     uint32_t get_overlapping_flags() const;
 
-    virtual bool has_only_one_rotation() const;
+    bool has_only_one_rotation() const override;
 
-    virtual size_t get_dimension() const;
+    size_t get_dimension() const override;
 
-    virtual bool is_replica() const;
+    bool is_replica() const override;
 
-    virtual size_t get_number_of_items() const;
+    size_t get_number_of_items() const override;
 
-    virtual void get_placement(int item_, placement & p_) const;
+    void get_placement(int item_, placement & p_) const override;
 
-    virtual size_t compute_index_map(std::vector<uint32_t> & map_,
-                                     int item_) const;
+    size_t compute_index_map(std::vector<uint32_t> & map_,
+                                     int item_) const override;
 
     const placement & get_basic_placement() const;
 
     regular_3d_mesh_placement();
 
-    virtual ~regular_3d_mesh_placement();
+    ~regular_3d_mesh_placement() override;
 
     bool is_initialized() const;
 
@@ -125,10 +125,10 @@ namespace geomtools {
 
     virtual void reset();
 
-    virtual void tree_dump(std::ostream & out_  = std::clog,
+    void tree_dump(std::ostream & out_  = std::clog,
                            const std::string & title_ = "geomutils::regular_grid_placement",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/regular_circular_placement.h
+++ b/source/bxgeomtools/include/geomtools/regular_circular_placement.h
@@ -37,11 +37,11 @@ namespace geomtools {
 
     void invalidate();
 
-    virtual size_t get_dimension() const;
+    size_t get_dimension() const override;
 
-    virtual bool is_replica() const;
+    bool is_replica() const override;
 
-    virtual bool has_only_one_rotation() const;
+    bool has_only_one_rotation() const override;
 
     void set_rotation_axis(rotation_axis_type);
 
@@ -75,12 +75,12 @@ namespace geomtools {
 
     void set_number_of_items(size_t n_);
 
-    virtual size_t get_number_of_items() const;
+    size_t get_number_of_items() const override;
 
-    virtual void get_placement(int item_, placement & p_) const;
+    void get_placement(int item_, placement & p_) const override;
 
-    virtual size_t compute_index_map(std::vector<uint32_t> & map_,
-                                     int item_) const;
+    size_t compute_index_map(std::vector<uint32_t> & map_,
+                                     int item_) const override;
 
     /// Default constructor
     regular_circular_placement();
@@ -94,7 +94,7 @@ namespace geomtools {
                                rotation_axis_type rotation_axis_ = ROTATION_AXIS_Z);
 
     /// Destructor
-    virtual ~regular_circular_placement();
+    ~regular_circular_placement() override;
 
     /// Initialization
     void initialize(const vector_3d & center_,
@@ -108,10 +108,10 @@ namespace geomtools {
     virtual void reset();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_  = std::clog,
+    void tree_dump(std::ostream & out_  = std::clog,
                            const std::string & title_ = "geomutils::regular_circular_placement",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/regular_grid_placement.h
+++ b/source/bxgeomtools/include/geomtools/regular_grid_placement.h
@@ -113,18 +113,18 @@ namespace geomtools {
 
     placement get_placement (int col_, int row_) const;
 
-    virtual bool has_only_one_rotation () const;
+    bool has_only_one_rotation () const override;
 
-    virtual size_t get_dimension () const;
+    size_t get_dimension () const override;
 
-    virtual bool is_replica () const;
+    bool is_replica () const override;
 
-    virtual size_t get_number_of_items () const;
+    size_t get_number_of_items () const override;
 
-    virtual void get_placement (int item_, placement & p_) const;
+    void get_placement (int item_, placement & p_) const override;
 
-    virtual size_t compute_index_map (std::vector<uint32_t> & map_,
-                                      int item_) const;
+    size_t compute_index_map (std::vector<uint32_t> & map_,
+                                      int item_) const override;
 
     regular_grid_placement ();
 
@@ -136,7 +136,7 @@ namespace geomtools {
                             int mode_,
                             bool centered_ = true);
 
-    virtual ~regular_grid_placement ();
+    ~regular_grid_placement () override;
 
     void init (const placement & basic_placement_,
                double column_step_,
@@ -148,10 +148,10 @@ namespace geomtools {
 
     virtual void reset ();
 
-    virtual void tree_dump (std::ostream & out_  = std::clog,
+    void tree_dump (std::ostream & out_  = std::clog,
                             const std::string & title_ = "geomutils::regular_grid_placement",
                             const std::string & indent_ = "",
-                            bool inherit_ = false) const;
+                            bool inherit_ = false) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/regular_linear_placement.h
+++ b/source/bxgeomtools/include/geomtools/regular_linear_placement.h
@@ -44,11 +44,11 @@ namespace geomtools {
 
   public:
 
-    virtual size_t get_dimension() const;
+    size_t get_dimension() const override;
 
-    virtual bool is_replica() const;
+    bool is_replica() const override;
 
-    virtual bool has_only_one_rotation() const;
+    bool has_only_one_rotation() const override;
 
     void set_replicant_axis(int);
     int  get_replicant_axis() const;
@@ -80,12 +80,12 @@ namespace geomtools {
 
     void set_number_of_items(size_t n_);
 
-    virtual size_t get_number_of_items() const;
+    size_t get_number_of_items() const override;
 
-    virtual void get_placement(int item_, placement & p_) const;
+    void get_placement(int item_, placement & p_) const override;
 
-    virtual size_t compute_index_map(std::vector<uint32_t> & map_,
-                                     int item_) const;
+    size_t compute_index_map(std::vector<uint32_t> & map_,
+                                     int item_) const override;
 
     /// Default constructor
     regular_linear_placement();
@@ -102,7 +102,7 @@ namespace geomtools {
                              int replicant_axis_ = REPLICANT_AXIS_NONE);
 
     /// Destructor
-    virtual ~regular_linear_placement();
+    ~regular_linear_placement() override;
 
     /// Initialization
     void init(const placement & basic_placement_,
@@ -119,10 +119,10 @@ namespace geomtools {
     virtual void reset();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_  = std::clog,
+    void tree_dump(std::ostream & out_  = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/regular_polygon.h
+++ b/source/bxgeomtools/include/geomtools/regular_polygon.h
@@ -65,7 +65,7 @@ namespace geomtools {
     static const unsigned int MIN_NUMBER_OF_SIDES = 3;
 
     /// Check the validity of the polygon
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the number of sides
     uint32_t get_n_sides() const;
@@ -77,7 +77,7 @@ namespace geomtools {
     double get_apothem() const;
 
     /// Return the perimeter
-    virtual double get_perimeter(uint32_t flags_ = ALL_PIECES) const;
+    double get_perimeter(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the length of a side
     double get_side_length() const;
@@ -101,7 +101,7 @@ namespace geomtools {
     virtual double get_diameter() const;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Compute the coordinates of a vertex given its index
     void get_vertex(int n_, double & x_, double & y_) const;
@@ -116,37 +116,37 @@ namespace geomtools {
     regular_polygon(uint32_t n_sides_, double r_, int mode_ = BUILD_BY_RADIUS);
 
     /// Destructor
-    virtual ~regular_polygon();
+    ~regular_polygon() override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check is a given point belongs to the surface of the 2D shape
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal direction at some position on the 2D shape's path
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = true,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find the intercept of a ray with the 2D shape's surfaces
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// \brief 3D rendering options
     enum rp_wires_rendering_option_type {
@@ -156,11 +156,11 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// Build an ordered collection of vertexes
-    virtual unsigned int compute_vertexes(vertex_col_type & vertexes_) const;
+    unsigned int compute_vertexes(vertex_col_type & vertexes_) const override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/replicated_boxed_model.h
+++ b/source/bxgeomtools/include/geomtools/replicated_boxed_model.h
@@ -43,25 +43,25 @@ namespace geomtools {
     double get_x () const;
     double get_y () const;
     double get_z () const;
-    virtual const geomtools::box & get_box () const;
+    const geomtools::box & get_box () const override;
     const geomtools::box & get_solid () const;
 
     replicated_boxed_model ();
 
-    virtual ~replicated_boxed_model ();
+    ~replicated_boxed_model () override;
 
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 
-    virtual void _at_construct (const std::string & name_,
+    void _at_construct (const std::string & name_,
                                 const datatools::properties & config_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
   private:
 
     const i_model *            _boxed_model_;

--- a/source/bxgeomtools/include/geomtools/replicated_circular_model.h
+++ b/source/bxgeomtools/include/geomtools/replicated_circular_model.h
@@ -46,7 +46,7 @@ namespace geomtools {
     const geomtools::tube & get_solid() const;
 
     /// Return the model Id
-    virtual std::string get_model_id() const;
+    std::string get_model_id() const override;
 
     /// Return a reference to the embedded the regular circular placement object
     const regular_circular_placement & get_replica_placement() const;
@@ -58,28 +58,28 @@ namespace geomtools {
     replicated_circular_model();
 
     /// Destructor
-    virtual ~replicated_circular_model();
+    ~replicated_circular_model() override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   protected:
 
     /// Pre-construction
-    virtual void _pre_construct(datatools::properties & setup_,
-                                models_col_type * models_ = 0);
+    void _pre_construct(datatools::properties & setup_,
+                                models_col_type * models_ = 0) override;
 
     /// Construction
-    virtual void _at_construct(const std::string & name_,
+    void _at_construct(const std::string & name_,
                                const datatools::properties & config_,
-                               models_col_type * models_ = 0);
+                               models_col_type * models_ = 0) override;
 
     /// Post-construction
-    virtual void _post_construct (datatools::properties & setup_,
-                                  models_col_type * models_ = 0);
+    void _post_construct (datatools::properties & setup_,
+                                  models_col_type * models_ = 0) override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/replicated_model.h
+++ b/source/bxgeomtools/include/geomtools/replicated_model.h
@@ -62,7 +62,7 @@ namespace geomtools {
     double get_z () const;
 
     /// Return a reference to the mother box
-    virtual const geomtools::box & get_box () const;
+    const geomtools::box & get_box () const override;
 
     /// Return a reference to the mother box
     const geomtools::box & get_solid () const;
@@ -71,31 +71,31 @@ namespace geomtools {
     replicated_model ();
 
     /// Destructor
-    virtual ~replicated_model ();
+    ~replicated_model () override;
 
     /// Return the model unique class Id
-    virtual std::string get_model_id() const;
+    std::string get_model_id() const override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 
     /// Pre-construction
-    virtual void _pre_construct (datatools::properties & setup_,
-                                 models_col_type * models_);
+    void _pre_construct (datatools::properties & setup_,
+                                 models_col_type * models_) override;
 
     /// Post construction
-    virtual void _post_construct (datatools::properties & setup_,
-                                  models_col_type * models_);
+    void _post_construct (datatools::properties & setup_,
+                                  models_col_type * models_) override;
 
     /// Construction
-    virtual void _at_construct (const std::string & name_,
+    void _at_construct (const std::string & name_,
                                 const datatools::properties & config_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
   private:
 
     const i_model *            _model_; /// Replicated model

--- a/source/bxgeomtools/include/geomtools/right_circular_conical_frustrum.h
+++ b/source/bxgeomtools/include/geomtools/right_circular_conical_frustrum.h
@@ -62,28 +62,28 @@ namespace geomtools {
     static const std::string & rccf_label();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the frustrum is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the minimum X
-    double get_xmin () const;
+    double get_xmin () const override;
 
     /// Return the maximum X
-    double get_xmax () const;
+    double get_xmax () const override;
 
     /// Return the minimum Y
-    double get_ymin () const;
+    double get_ymin () const override;
 
     /// Return the maximum Y
-    double get_ymax () const;
+    double get_ymax () const override;
 
     /// Return the minimum Z
-    double get_zmin () const;
+    double get_zmin () const override;
 
     /// Return the maximum Z
-    double get_zmax () const;
+    double get_zmax () const override;
 
     /// Set the Z dimension
     void set_z(double);
@@ -174,13 +174,13 @@ namespace geomtools {
                                     double delta_angle_);
 
     /// Destructor
-    virtual ~right_circular_conical_frustrum();
+    ~right_circular_conical_frustrum() override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
     /// Compute the inner face
     void compute_inner_face(right_circular_conical_nappe & in_) const;
@@ -231,42 +231,42 @@ namespace geomtools {
     void compute_stop_angle_face(quadrangle & qface_, triangle & tface_, placement &) const;
 
     /// Compute informations about the faces of this solid shape
-    virtual unsigned int compute_faces(face_info_collection_type &) const;
+    unsigned int compute_faces(face_info_collection_type &) const override;
 
     /// Compute the surface
-    virtual double get_surface(uint32_t mask_ = FACE_ALL) const;
+    double get_surface(uint32_t mask_ = FACE_ALL) const override;
 
     /// Compute the volume
-    virtual double get_volume(uint32_t flags_ = VOLUME_BULK) const;
+    double get_volume(uint32_t flags_ = VOLUME_BULK) const override;
 
     /// Check if a point is inside the frustrum
-    virtual bool is_inside (const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside (const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the frustrum
-    virtual bool is_outside (const vector_3d &,
-                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside (const vector_3d &,
+                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Compute the normal to the surface of the furstrum
-    virtual vector_3d get_normal_on_surface (const vector_3d & position_,
-                                             const face_identifier & ) const;
+    vector_3d get_normal_on_surface (const vector_3d & position_,
+                                             const face_identifier & ) const override;
 
     /// Find the intercept point with a face of the frustrum
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Initialize the frustrum from properties
-    virtual void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset the frustrum
-    virtual void reset();
+    void reset() override;
 
     /// \brief 3D rendering options
     enum rccf_wires_rendering_option_type {
@@ -286,8 +286,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 
@@ -295,7 +295,7 @@ namespace geomtools {
     void _set_defaults();
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/right_circular_conical_nappe.h
+++ b/source/bxgeomtools/include/geomtools/right_circular_conical_nappe.h
@@ -34,10 +34,10 @@ namespace geomtools {
     static const std::string & right_circular_conical_nappe_label();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the rectangle is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Set the Z dimension
     void set_z(double);
@@ -88,7 +88,7 @@ namespace geomtools {
     double get_cone_angle() const;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Default constructor
     right_circular_conical_nappe();
@@ -106,28 +106,28 @@ namespace geomtools {
                                  double delta_angle_);
 
     /// Destructor
-    virtual ~right_circular_conical_nappe();
+    ~right_circular_conical_nappe() override;
 
     /// Check if a point is on the surface
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal at a given position of the surface
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = true,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// \brief 3D rendering options
     enum rccn_wires_rendering_option_type {
@@ -143,14 +143,14 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset the shape
-    void reset();
+    void reset() override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/right_polygonal_frustrum.h
+++ b/source/bxgeomtools/include/geomtools/right_polygonal_frustrum.h
@@ -56,28 +56,28 @@ namespace geomtools {
     static const std::string & rpf_label();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the frustrum is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the minimum X
-    double get_xmin() const;
+    double get_xmin() const override;
 
     /// Return the maximum X
-    double get_xmax() const;
+    double get_xmax() const override;
 
     /// Return the minimum Y
-    double get_ymin() const;
+    double get_ymin() const override;
 
     /// Return the maximum Y
-    double get_ymax() const;
+    double get_ymax() const override;
 
     /// Return the minimum Z
-    double get_zmin() const;
+    double get_zmin() const override;
 
     /// Return the maximum Z
-    double get_zmax() const;
+    double get_zmax() const override;
 
     /// Return the number of sides
     uint32_t get_n_sides() const;
@@ -154,13 +154,13 @@ namespace geomtools {
                              double z_);
 
     /// Destructor
-    virtual ~right_polygonal_frustrum();
+    ~right_polygonal_frustrum() override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
     /// Compute the inner face
     void compute_inner_face(composite_surface & face_) const;
@@ -175,7 +175,7 @@ namespace geomtools {
     void compute_bottom_face(composite_surface & bottom_face_, placement &) const;
 
     /// Compute informations about the faces of this solid shape
-    virtual unsigned int compute_faces(face_info_collection_type &) const;
+    unsigned int compute_faces(face_info_collection_type &) const override;
 
     /// Compute the outer radius at given z
     double compute_outer_radius(double z_) const;
@@ -184,39 +184,39 @@ namespace geomtools {
     double compute_inner_radius(double z_) const;
 
     /// Compute the surface
-    virtual double get_surface(uint32_t mask_ = FACE_ALL) const;
+    double get_surface(uint32_t mask_ = FACE_ALL) const override;
 
     /// Compute the volume
-    virtual double get_volume(uint32_t flags_ = VOLUME_BULK) const;
+    double get_volume(uint32_t flags_ = VOLUME_BULK) const override;
 
     /// Check if a point is inside the frustrum
-    virtual bool is_inside (const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside (const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the frustrum
-    virtual bool is_outside (const vector_3d &,
-                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside (const vector_3d &,
+                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Compute the normal to the surface of the furstrum
-    virtual vector_3d get_normal_on_surface (const vector_3d & position_,
-                                             const face_identifier & ) const;
+    vector_3d get_normal_on_surface (const vector_3d & position_,
+                                             const face_identifier & ) const override;
 
     /// Find the intercept point with a face of the frustrum
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Initialize the frustrum from properties
-    virtual void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset the frustrum
-    virtual void reset();
+    void reset() override;
 
     /// \brief 3D rendering options
     enum rpf_wires_rendering_option_type {
@@ -232,8 +232,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 
@@ -241,7 +241,7 @@ namespace geomtools {
     void _set_defaults();
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/rotated_boxed_model.h
+++ b/source/bxgeomtools/include/geomtools/rotated_boxed_model.h
@@ -36,7 +36,7 @@ namespace geomtools {
 
     const i_model & get_boxed_model () const;
 
-    virtual const geomtools::box & get_box () const;
+    const geomtools::box & get_box () const override;
 
     const geomtools::box & get_solid () const;
 
@@ -44,20 +44,20 @@ namespace geomtools {
 
     rotated_boxed_model ();
 
-    virtual ~rotated_boxed_model ();
+    ~rotated_boxed_model () override;
 
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 
-    virtual void _at_construct (const std::string & name_,
+    void _at_construct (const std::string & name_,
                                 const datatools::properties & config_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
   private:
 
     const i_model *  _boxed_model_;

--- a/source/bxgeomtools/include/geomtools/shape_factory.h
+++ b/source/bxgeomtools/include/geomtools/shape_factory.h
@@ -41,7 +41,7 @@ namespace geomtools {
     shape_factory();
 
     //! Destructor
-    virtual ~shape_factory();
+    ~shape_factory() override;
 
     //! Return a reference to a non mutable dictionary of shapes
     const i_object_3d::handle_dict_type & get_shapes() const;
@@ -94,10 +94,10 @@ namespace geomtools {
     void parse_shapes(const datatools::properties & defs_);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/simple_boxed_model.h
+++ b/source/bxgeomtools/include/geomtools/simple_boxed_model.h
@@ -46,26 +46,26 @@ namespace geomtools {
 
     const std::string & get_material_name () const;
 
-    virtual const geomtools::box & get_box () const;
+    const geomtools::box & get_box () const override;
 
     const geomtools::box & get_solid () const;
 
     simple_boxed_model ();
 
-    virtual ~simple_boxed_model ();
+    ~simple_boxed_model () override;
 
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 
-    virtual void _at_construct (const std::string & name_,
+    void _at_construct (const std::string & name_,
                                 const datatools::properties & config_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
   private:
 
     std::string    _material_name_;

--- a/source/bxgeomtools/include/geomtools/simple_polygon.h
+++ b/source/bxgeomtools/include/geomtools/simple_polygon.h
@@ -58,10 +58,10 @@ namespace geomtools {
     static const std::string & simple_polygon_label();
 
     /// Check the validity of the simple polygon
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// \brief Data for a wall segment
     struct wall_segment_type {
@@ -84,10 +84,10 @@ namespace geomtools {
     build_mode_type get_build_mode() const;
 
     /// Return the perimeter
-    virtual double get_perimeter(uint32_t flags_ = ALL_PIECES) const;
+    double get_perimeter(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the number of vertices
     unsigned int get_number_of_vertices() const;
@@ -125,16 +125,16 @@ namespace geomtools {
     simple_polygon();
 
     /// Destructor
-    virtual ~simple_polygon();
+    ~simple_polygon() override;
 
     /// Check is a given point belongs to the surface of the 2D shape
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal direction at some position on the 2D shape's path
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = false,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if the polygon is clockwise
     bool is_clockwise() const;
@@ -143,16 +143,16 @@ namespace geomtools {
     bool is_anticlockwise() const;
 
     /// Find the intercept of a ray with the 2D shape's surfaces
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// \brief 3D rendering options
     enum simple_polygon_wires_rendering_option_type {
@@ -163,11 +163,11 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// Build an ordered collection of vertexes
-    virtual unsigned int compute_vertexes(vertex_col_type & vertexes_) const;
+    unsigned int compute_vertexes(vertex_col_type & vertexes_) const override;
 
     /// Return the number of triangles
     unsigned int number_of_triangles() const;
@@ -185,10 +185,10 @@ namespace geomtools {
     bool is_initialized() const;
 
     /// Initialization
-    void initialize(const datatools::properties &, const handle_dict_type * objects_ = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * objects_ = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Find the intersection between two 2D segments
     static bool find_segment_2d_intersection(const vector_2d & a_,

--- a/source/bxgeomtools/include/geomtools/simple_shaped_model.h
+++ b/source/bxgeomtools/include/geomtools/simple_shaped_model.h
@@ -87,26 +87,26 @@ namespace geomtools {
 
     simple_shaped_model ();
 
-    virtual ~simple_shaped_model ();
+    ~simple_shaped_model () override;
 
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 
-    virtual void _pre_construct (datatools::properties & setup_,
-                                 models_col_type * models_);
+    void _pre_construct (datatools::properties & setup_,
+                                 models_col_type * models_) override;
 
-    virtual void _post_construct (datatools::properties & setup_,
-                                  models_col_type * models_);
+    void _post_construct (datatools::properties & setup_,
+                                  models_col_type * models_) override;
 
-    virtual void _at_construct (const std::string & name_,
+    void _at_construct (const std::string & name_,
                                 const datatools::properties & config_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
 
     virtual void _construct_box (const std::string & name_,
                                  const datatools::properties & config_,

--- a/source/bxgeomtools/include/geomtools/simple_world_model.h
+++ b/source/bxgeomtools/include/geomtools/simple_world_model.h
@@ -40,20 +40,20 @@ namespace geomtools {
 
     simple_world_model ();
 
-    virtual ~simple_world_model ();
+    ~simple_world_model () override;
 
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 
-    virtual void _at_construct (const std::string & name_,
+    void _at_construct (const std::string & name_,
                                 const datatools::properties & setup_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/smart_id_locator.h
+++ b/source/bxgeomtools/include/geomtools/smart_id_locator.h
@@ -87,15 +87,15 @@ namespace geomtools {
     const std::list<const geom_info *> & get_ginfos () const;
 
     /// Check if a given geom Id is valid
-    virtual bool validate_id (const geom_id & id_) const;
+    bool validate_id (const geom_id & id_) const override;
 
     /// Retrieve the geometry info object from its geometry Id
-    virtual const geom_info & get_geom_info (const geom_id & id_) const;
+    const geom_info & get_geom_info (const geom_id & id_) const override;
 
     /// Retrieve the geometry Id of the volume from the world position
-    virtual const geom_id & get_geom_id (const vector_3d & world_position_,
+    const geom_id & get_geom_id (const vector_3d & world_position_,
                                          int type_ = geom_id::INVALID_TYPE,
-                                         double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                         double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
     void tree_dump(std::ostream & out_ = std::clog,

--- a/source/bxgeomtools/include/geomtools/sphere.h
+++ b/source/bxgeomtools/include/geomtools/sphere.h
@@ -65,17 +65,17 @@ namespace geomtools {
 
     static const std::string & sphere_label();
 
-    double get_xmin() const;
+    double get_xmin() const override;
 
-    double get_xmax() const;
+    double get_xmax() const override;
 
-    double get_ymin() const;
+    double get_ymin() const override;
 
-    double get_ymax() const;
+    double get_ymax() const override;
 
-    double get_zmin() const;
+    double get_zmin() const override;
 
-    double get_zmax() const;
+    double get_zmax() const override;
 
     double get_r() const;
 
@@ -168,51 +168,51 @@ namespace geomtools {
     sphere(double radius_min_, double radius_max_);
 
     /// Destructor
-    virtual ~sphere();
+    ~sphere() override;
 
     /// Return the name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Return the value of some parameter
     virtual double get_parameter(const std::string &) const;
 
     /// Check the validity of the sphere
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Initialize the sphere from properties
-    virtual void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset the sphere
-    virtual void reset();
+    void reset() override;
 
     /// Compute the surface
-     virtual double get_surface(uint32_t mask_ = FACE_ALL) const;
+     double get_surface(uint32_t mask_ = FACE_ALL) const override;
 
     /// Compute the volume
-    virtual double get_volume(uint32_t flags_ = 0) const;
+    double get_volume(uint32_t flags_ = 0) const override;
 
     /// Check if a point is inside the tube
-    virtual bool is_inside(const vector_3d &,
-                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside(const vector_3d &,
+                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the tube
-    virtual bool is_outside(const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside(const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Find the intercept point with a face of the sphere
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Compute the side face
     void compute_side_face(faces_mask_type, spherical_sector &) const;
@@ -242,7 +242,7 @@ namespace geomtools {
     void compute_stop_phi_face(disk &, placement &) const;
 
     /// Return a collection of face info objects
-    virtual unsigned int compute_faces(face_info_collection_type & faces_) const;
+    unsigned int compute_faces(face_info_collection_type & faces_) const override;
 
 
     friend std::ostream &
@@ -251,10 +251,10 @@ namespace geomtools {
     friend std::istream &
     operator>>(std::istream &, sphere &);
 
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// \brief 3D rendering options
     enum sphere_wires_rendering_option_type {
@@ -275,8 +275,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);
@@ -287,7 +287,7 @@ namespace geomtools {
     void _set_default();
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/spherical_extrusion_box_model.h
+++ b/source/bxgeomtools/include/geomtools/spherical_extrusion_box_model.h
@@ -48,19 +48,19 @@ namespace geomtools {
     const geomtools::subtraction_3d & get_solid() const;
 
     //! Return the model unique identifier
-     virtual std::string get_model_id() const;
+     std::string get_model_id() const override;
 
     //! Constructor
     spherical_extrusion_box_model();
 
     //! Destructor
-    virtual ~spherical_extrusion_box_model();
+    ~spherical_extrusion_box_model() override;
 
     //! Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
 
     /// \brief Special wires 3D rendering
     struct wires_drawer : public i_wires_drawer<spherical_extrusion_box_model>
@@ -78,19 +78,19 @@ namespace geomtools {
       wires_drawer(const spherical_extrusion_box_model & model_);
 
       //! Destructor
-      virtual ~wires_drawer();
+      ~wires_drawer() override;
 
       //! Generate a list of polylines representing the contour of the shape (for display clients)
-      virtual void generate_wires_self(wires_type & wires_,
-                                       uint32_t options_ = 0) const;
+      void generate_wires_self(wires_type & wires_,
+                                       uint32_t options_ = 0) const override;
 
     };
 
   protected:
 
-    virtual void _at_construct(const std::string & name_,
+    void _at_construct(const std::string & name_,
                                const datatools::properties & setup_,
-                               geomtools::models_col_type * models_ = 0);
+                               geomtools::models_col_type * models_ = 0) override;
   private:
 
     std::string               _material_;

--- a/source/bxgeomtools/include/geomtools/spherical_extrusion_cylinder_model.h
+++ b/source/bxgeomtools/include/geomtools/spherical_extrusion_cylinder_model.h
@@ -50,19 +50,19 @@ namespace geomtools {
     const geomtools::subtraction_3d & get_solid() const;
 
     //! Return the model unique identifier
-    virtual std::string get_model_id() const;
+    std::string get_model_id() const override;
 
     //! Constructor
     spherical_extrusion_cylinder_model();
 
     //! Destructor
-    virtual ~spherical_extrusion_cylinder_model();
+    ~spherical_extrusion_cylinder_model() override;
 
     //! Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// \brief Special wires 3D rendering
     struct wires_drawer : public i_wires_drawer<spherical_extrusion_cylinder_model>
@@ -80,19 +80,19 @@ namespace geomtools {
       wires_drawer(const spherical_extrusion_cylinder_model & model_);
 
       //! Destructor
-      virtual ~wires_drawer();
+      ~wires_drawer() override;
 
       //! Generate a list of polylines representing the contour of the shape (for display clients)
-      virtual void generate_wires_self(wires_type & wires_,
-                                       uint32_t options_ = 0) const;
+      void generate_wires_self(wires_type & wires_,
+                                       uint32_t options_ = 0) const override;
 
     };
 
   protected:
 
-    virtual void _at_construct(const std::string & name_,
+    void _at_construct(const std::string & name_,
                                const datatools::properties & setup_,
-                               geomtools::models_col_type * models_ = 0);
+                               geomtools::models_col_type * models_ = 0) override;
   private:
 
     std::string               _material_; //!< Material name

--- a/source/bxgeomtools/include/geomtools/spherical_sector.h
+++ b/source/bxgeomtools/include/geomtools/spherical_sector.h
@@ -29,10 +29,10 @@ namespace geomtools {
     static const std::string & spherical_sector_label();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the rectangle is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Set the radius
     void set_radius(double new_value_);
@@ -89,7 +89,7 @@ namespace geomtools {
     double get_delta_phi() const;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Default constructor
     spherical_sector();
@@ -105,34 +105,34 @@ namespace geomtools {
                      double delta_phi_);
 
     /// Destructor
-    virtual ~spherical_sector();
+    ~spherical_sector() override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Check if a point is on the surface
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal at a given position of the surface
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = true,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// \brief 3D rendering options
     enum sphesec_wires_rendering_option_type {
@@ -150,8 +150,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/stacked_model.h
+++ b/source/bxgeomtools/include/geomtools/stacked_model.h
@@ -106,7 +106,7 @@ namespace geomtools {
     const std::string & get_envelope_shape() const;
 
     //
-    virtual const geomtools::box & get_box () const;
+    const geomtools::box & get_box () const override;
 
     const geomtools::box & get_solid () const;
 
@@ -130,26 +130,26 @@ namespace geomtools {
 
     const stacked_dict_type & get_models () const;
 
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
     /// Default constructor
     stacked_model ();
 
     /// Destructor
-    virtual ~stacked_model ();
+    ~stacked_model () override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 
     /// Construction
-    virtual void _at_construct (const std::string & name_,
+    void _at_construct (const std::string & name_,
                                 const datatools::properties & config_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/subtraction_3d.h
+++ b/source/bxgeomtools/include/geomtools/subtraction_3d.h
@@ -29,45 +29,45 @@ namespace geomtools {
     static const std::string & subtraction_3d_label();
 
     /// Return the name of the shape type
-    std::string get_shape_name () const;
+    std::string get_shape_name () const override;
 
     /// Default constructor
     subtraction_3d ();
 
     /// Destructor
-    virtual ~subtraction_3d ();
+    ~subtraction_3d () override;
 
     /// Check if a point is inside the cylinder
-    virtual bool is_inside(const vector_3d & position_,
-                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside(const vector_3d & position_,
+                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the cylinder
-    virtual bool is_outside(const vector_3d & position_,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside(const vector_3d & position_,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_invalid(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept (const vector_3d & from_,
+    bool find_intercept (const vector_3d & from_,
                                  const vector_3d & direction_,
                                  face_intercept_info & intercept_,
-                                 double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                 double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 
     /// Destructor
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
     // Registration interface :
     GEOMTOOLS_OBJECT_3D_REGISTRATION_INTERFACE(subtraction_3d)

--- a/source/bxgeomtools/include/geomtools/surrounded_boxed_model.h
+++ b/source/bxgeomtools/include/geomtools/surrounded_boxed_model.h
@@ -76,7 +76,7 @@ namespace geomtools {
 
     void set_material_name (const std::string &);
 
-    virtual const geomtools::box & get_box () const;
+    const geomtools::box & get_box () const override;
 
     const geomtools::box & get_solid () const;
 
@@ -110,22 +110,22 @@ namespace geomtools {
     surrounded_boxed_model ();
 
     /// Destructor
-    virtual ~surrounded_boxed_model ();
+    ~surrounded_boxed_model () override;
 
-    virtual std::string get_model_id () const;
+    std::string get_model_id () const override;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
   protected:
 
     /// Construction
-    virtual void _at_construct (const std::string & name_,
+    void _at_construct (const std::string & name_,
                                 const datatools::properties & config_,
-                                models_col_type * models_ = 0);
+                                models_col_type * models_ = 0) override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/tessellation.h
+++ b/source/bxgeomtools/include/geomtools/tessellation.h
@@ -308,7 +308,7 @@ namespace geomtools {
     typedef std::map<unsigned int, facet_segment> facet_segments_col_type;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     static bool validate_index(int);
 
@@ -316,16 +316,16 @@ namespace geomtools {
     bool is_consistent() const;
 
     /// Check if the face identification scheme is based on face bits
-    bool using_face_id_bits() const;
+    bool using_face_id_bits() const override;
 
     /// Check if the face identification scheme is based on face index
-    bool using_face_id_index() const;
+    bool using_face_id_index() const override;
 
     /// Default constructor
     tessellated_solid();
 
     /// Destructor
-    virtual ~tessellated_solid();
+    ~tessellated_solid() override;
 
     /// Return the collection of vertexes
     const vertices_col_type & vertices() const;
@@ -371,22 +371,22 @@ namespace geomtools {
     const mygsl::min_max & get_bounding_box_z() const;
 
     /// Return the min X coordinates (bounding box)
-    double get_xmin() const;
+    double get_xmin() const override;
 
     /// Return the max X coordinates (bounding box)
-    double get_xmax() const;
+    double get_xmax() const override;
 
     /// Return the min Y coordinates (bounding box)
-    double get_ymin() const;
+    double get_ymin() const override;
 
     /// Return the max Y coordinates (bounding box)
-    double get_ymax() const;
+    double get_ymax() const override;
 
     /// Return the min Z coordinates (bounding box)
-    double get_zmin() const;
+    double get_zmin() const override;
 
     /// Return the max Z coordinates (bounding box)
-    double get_zmax() const;
+    double get_zmax() const override;
 
     /// Print
     void print_xyz(std::ostream & out_) const;
@@ -395,30 +395,30 @@ namespace geomtools {
     void dump(std::ostream & out_ = std::clog) const;
 
     /// Check if a point is inside the frustrum
-    virtual bool is_inside (const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside (const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the frustrum
-    virtual bool is_outside (const vector_3d &,
-                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside (const vector_3d &,
+                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::FACE_INDEX_ANY,
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Compute the normal to the surface of the furstrum
-    virtual vector_3d get_normal_on_surface (const vector_3d & position_,
-                                             const face_identifier & ) const;
+    vector_3d get_normal_on_surface (const vector_3d & position_,
+                                             const face_identifier & ) const override;
 
     /// Find the intercept point with a face of the frustrum
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Compute informations about the faces of this solid shape
-    virtual unsigned int compute_faces(face_info_collection_type &) const;
+    unsigned int compute_faces(face_info_collection_type &) const override;
 
     /// \brief 3D rendering options
     enum tessella_wires_rendering_option_type {
@@ -429,39 +429,39 @@ namespace geomtools {
     };
 
     /// Generate a list of polylines representing the contour of the shape (for display clients)
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
 
     /// Initialize from properties
-    virtual void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Initialize from STL file
     void initialize_from_stl(const std::string & filename_,
                              double length_unit_);
 
     /// Check the validity
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & a_out         = std::clog,
+    void tree_dump(std::ostream & a_out         = std::clog,
                            const std::string & a_title  = "",
                            const std::string & a_indent = "",
-                           bool a_inherit          = false) const;
+                           bool a_inherit          = false) const override;
 
   protected:
 
     /// Executed at lock stage
-    virtual void _at_lock();
+    void _at_lock() override;
 
     /// Executed at unlock stage
-    virtual void _at_unlock();
+    void _at_unlock() override;
 
     /// Build the bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
     /// Compute the collection of facet segments
     void _compute_facet_segments();

--- a/source/bxgeomtools/include/geomtools/toroid_nappe.h
+++ b/source/bxgeomtools/include/geomtools/toroid_nappe.h
@@ -29,10 +29,10 @@ namespace geomtools {
     static const std::string & toroid_nappe_label();
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the rectangle is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Set the sweep radius
     void set_sweep_radius(double new_value_);
@@ -68,7 +68,7 @@ namespace geomtools {
     double get_delta_phi() const;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Default constructor
     toroid_nappe();
@@ -83,34 +83,34 @@ namespace geomtools {
                  double delta_phi_);
 
     /// Destructor
-    virtual ~toroid_nappe();
+    ~toroid_nappe() override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Check if a point is on the surface
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal at a given position of the surface
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = true,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// \brief 3D rendering options
     enum toroid_nappe_wires_rendering_option_type {
@@ -122,8 +122,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/torus.h
+++ b/source/bxgeomtools/include/geomtools/torus.h
@@ -72,25 +72,25 @@ namespace geomtools {
                                      placement & face_placement_) const;
 
     /// Compute informations about the faces of this solid shape
-    virtual unsigned int compute_faces(face_info_collection_type & faces) const;
+    unsigned int compute_faces(face_info_collection_type & faces) const override;
 
     /// Return the min X coordinates (bounding box)
-    double get_xmin () const;
+    double get_xmin () const override;
 
     /// Return the max X coordinates (bounding box)
-    double get_xmax () const;
+    double get_xmax () const override;
 
     /// Return the min Y coordinates (bounding box)
-    double get_ymin () const;
+    double get_ymin () const override;
 
     /// Return the max Y coordinates (bounding box)
-    double get_ymax () const;
+    double get_ymax () const override;
 
     /// Return the min Z coordinates (bounding box)
-    double get_zmin () const;
+    double get_zmin () const override;
 
     /// Return the max Z coordinates (bounding box)
-    double get_zmax () const;
+    double get_zmax () const override;
 
     /// Return the radius of the solid torus
     double get_sweep_radius() const;
@@ -153,52 +153,52 @@ namespace geomtools {
     torus(double sweep_radius_, double outside_radius_, double inside_radius_, double start_phi_, double delta_phi_);
 
     /// Destructor
-    virtual ~torus();
+    ~torus() override;
 
     /// Return the name of the shape
-    virtual std::string get_shape_name () const;
+    std::string get_shape_name () const override;
 
     /// Return a parameter by name
     virtual double get_parameter (const std::string &) const;
 
     /// Check the validity
-    bool is_valid () const;
+    bool is_valid () const override;
 
     /// Initialize from properties
-    virtual void initialize(const datatools::properties &,
-                            const handle_dict_type *);
+    void initialize(const datatools::properties &,
+                            const handle_dict_type *) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Compute the surface of the cylinder
-    virtual double get_surface (uint32_t mask_ = FACE_ALL) const;
+    double get_surface (uint32_t mask_ = FACE_ALL) const override;
 
     /// Compute the volume of the cylinder
-    virtual double get_volume (uint32_t flags_ = 0) const;
+    double get_volume (uint32_t flags_ = 0) const override;
 
     /// Check if a point is inside the cylinder
-    virtual bool is_inside (const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside (const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the cylinder
-    virtual bool is_outside (const vector_3d &,
-                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside (const vector_3d &,
+                             double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept (const vector_3d & from_,
+    bool find_intercept (const vector_3d & from_,
                                  const vector_3d & direction_,
                                  face_intercept_info & intercept_,
-                                 double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                 double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     friend std::ostream &
     operator<< (std::ostream &, const torus &);
@@ -207,10 +207,10 @@ namespace geomtools {
     operator>> (std::istream &, torus &);
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_          = false) const;
+                            bool inherit_          = false) const override;
 
     /// \brief 3D rendering options
     enum torus_wires_rendering_option_type {
@@ -226,8 +226,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);
@@ -238,7 +238,7 @@ namespace geomtools {
     void _set_defaults();
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/triangle.h
+++ b/source/bxgeomtools/include/geomtools/triangle.h
@@ -36,13 +36,13 @@ namespace geomtools {
     static const std::string & triangle_label();
 
     /// Check the validity of the triangle
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Return the perimeter
-    virtual double get_perimeter(uint32_t flags_ = ALL_PIECES) const;
+    double get_perimeter(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Return the surface
-    virtual double get_surface(uint32_t flags_ = ALL_PIECES) const;
+    double get_surface(uint32_t flags_ = ALL_PIECES) const override;
 
     /// Check the alignment of 3 points candidate to make a triangle
     static bool check_alignement(const geomtools::vector_3d & v0_,
@@ -84,37 +84,37 @@ namespace geomtools {
     triangle(const vector_3d & p0_, const vector_3d & p1_, const vector_3d & p2_);
 
     /// Destructor
-    virtual ~triangle();
+    ~triangle() override;
 
     /// Initialize from properties and a dictionary of 3D-objects
-    void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check is a given point belongs to the surface of the 2D shape
-    virtual bool is_on_surface(const vector_3d &,
-                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_on_surface(const vector_3d &,
+                               double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the normal direction at some position on the 2D shape's path
-    virtual vector_3d get_normal_on_surface(const vector_3d & position_,
+    vector_3d get_normal_on_surface(const vector_3d & position_,
                                             bool check_ = false,
-                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Find the intercept of a ray with the 2D shape's surfaces
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double tolerance_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_ = "",
                            const std::string & indent_ = "",
-                           bool inherit_= false) const;
+                           bool inherit_= false) const override;
 
     /// Compute the vectors of the proper frame (V0, VOV1, V0V2, V0V1^V0V1) system
     void compute_proper_frame(vector_3d & u0_, vector_3d & u1_, vector_3d & u2_) const;
@@ -140,11 +140,11 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// Build an ordered collection of vertexes
-    virtual unsigned int compute_vertexes(vertex_col_type & vertexes_) const;
+    unsigned int compute_vertexes(vertex_col_type & vertexes_) const override;
 
   protected:
 

--- a/source/bxgeomtools/include/geomtools/tube.h
+++ b/source/bxgeomtools/include/geomtools/tube.h
@@ -93,25 +93,25 @@ namespace geomtools {
     bool has_inner_face() const;
 
     /// Return a collection of face info objects
-    virtual unsigned int compute_faces(face_info_collection_type & faces_) const;
+    unsigned int compute_faces(face_info_collection_type & faces_) const override;
 
     /// Return the minimum X
-    double get_xmin() const;
+    double get_xmin() const override;
 
     /// Return the maximum X
-    double get_xmax() const;
+    double get_xmax() const override;
 
     /// Return the minimum Y
-    double get_ymin() const;
+    double get_ymin() const override;
 
     /// Return the maximum Y
-    double get_ymax() const;
+    double get_ymax() const override;
 
     /// Return the minimum Z
-    double get_zmin() const;
+    double get_zmin() const override;
 
     /// Return the maximum Z
-    double get_zmax() const;
+    double get_zmax() const override;
 
     /// Return the Z dimension
     double get_z() const;
@@ -200,10 +200,10 @@ namespace geomtools {
     tube(double inner_radius_, double outer_radius_, double z_, double start_phi_, double delta_phi_);
 
     /// Destructor
-    virtual ~tube();
+    ~tube() override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Return a parameter given its name
     virtual double get_parameter(const std::string &) const;
@@ -212,42 +212,42 @@ namespace geomtools {
     bool is_extruded() const;
 
     /// Check if the tube is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Initialize the tube from properties
-    virtual void initialize(const datatools::properties &, const handle_dict_type * = 0);
+    void initialize(const datatools::properties &, const handle_dict_type * = 0) override;
 
     /// Reset the tube
-    virtual void reset();
+    void reset() override;
 
     /// Compute the surface
-    virtual double get_surface(uint32_t mask_ = FACE_ALL) const;
+    double get_surface(uint32_t mask_ = FACE_ALL) const override;
 
     /// Compute the volume
-    virtual double get_volume(uint32_t flags_ = VOLUME_BULK) const;
+    double get_volume(uint32_t flags_ = VOLUME_BULK) const override;
 
     /// Check if a point is inside the tube
-    virtual bool is_inside(const vector_3d &,
-                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside(const vector_3d &,
+                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the tube
-    virtual bool is_outside(const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside(const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Find the intercept point with a face of the tube
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Output operator
     friend std::ostream &
@@ -258,10 +258,10 @@ namespace geomtools {
     operator>>(std::istream &, tube &);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
 
     /// \brief 3D rendering options
     enum tube_wires_rendering_option_type {
@@ -281,8 +281,8 @@ namespace geomtools {
     };
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);
@@ -293,7 +293,7 @@ namespace geomtools {
     void _set_defaults();
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
   private:
 

--- a/source/bxgeomtools/include/geomtools/union_3d.h
+++ b/source/bxgeomtools/include/geomtools/union_3d.h
@@ -30,45 +30,45 @@ namespace geomtools {
     static const std::string & union_3d_label();
 
     /// Return the name of the shape type
-    std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Default constructor
     union_3d();
 
     /// Destructor
-    virtual ~union_3d();
+    ~union_3d() override;
 
     /// Check if a point is inside the cylinder
-    virtual bool is_inside(const vector_3d & position_,
-                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside(const vector_3d & position_,
+                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the cylinder
-    virtual bool is_outside(const vector_3d & position_,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside(const vector_3d & position_,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_invalid(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the vector normal to the surface at some position
-    virtual vector_3d get_normal_on_surface(const vector_3d & a_position,
-                                            const face_identifier & a_surface_bit) const;
+    vector_3d get_normal_on_surface(const vector_3d & a_position,
+                                            const face_identifier & a_surface_bit) const override;
 
     /// Find the intercept point of a segment with the surface
-    virtual bool find_intercept (const vector_3d & from_,
+    bool find_intercept (const vector_3d & from_,
                                  const vector_3d & direction_,
                                  face_intercept_info & intercept_,
-                                 double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                 double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Generate a sequence of polylines for wires 3D rendering
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
   protected:
 
     /// Destructor
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
     // Registration interface :
     GEOMTOOLS_OBJECT_3D_REGISTRATION_INTERFACE(union_3d)

--- a/source/bxgeomtools/include/geomtools/wall_solid.h
+++ b/source/bxgeomtools/include/geomtools/wall_solid.h
@@ -60,17 +60,17 @@ namespace geomtools {
                      | FACE_TOP)
     };
 
-    virtual double get_xmin() const;
+    double get_xmin() const override;
 
-    virtual double get_xmax() const;
+    double get_xmax() const override;
 
-    virtual double get_ymin() const;
+    double get_ymin() const override;
 
-    virtual double get_ymax() const;
+    double get_ymax() const override;
 
-    virtual double get_zmin() const;
+    double get_zmin() const override;
 
-    virtual double get_zmax() const;
+    double get_zmax() const override;
 
     /// Return the Z dimension
     double get_z() const;
@@ -88,19 +88,19 @@ namespace geomtools {
     wall_solid();
 
     //! Destructor
-    virtual ~wall_solid();
+    ~wall_solid() override;
 
     /// Return the identifier/name of the shape
-    virtual std::string get_shape_name() const;
+    std::string get_shape_name() const override;
 
     /// Check if the solid is valid
-    bool is_valid() const;
+    bool is_valid() const override;
 
     /// Main initialization method from a container of configuration parameters
-    virtual void initialize(const datatools::properties & setup_, const handle_dict_type * = 0);
+    void initialize(const datatools::properties & setup_, const handle_dict_type * = 0) override;
 
     /// Reset/invalidate the solid
-    virtual void reset();
+    void reset() override;
 
     /// Compute the bottom face
     void compute_bottom_face(composite_surface & face_,
@@ -114,42 +114,42 @@ namespace geomtools {
     void compute_side_face(composite_surface & face_) const;
 
     /// Compute informations about the faces of this solid shape
-    virtual unsigned int compute_faces(face_info_collection_type &) const;
+    unsigned int compute_faces(face_info_collection_type &) const override;
 
     /// Compute the volume
-    virtual double get_volume(uint32_t flags_ = 0) const;
+    double get_volume(uint32_t flags_ = 0) const override;
 
     /// Compute the surface
-    virtual double get_surface(uint32_t mask_ = FACE_ALL) const;
+    double get_surface(uint32_t mask_ = FACE_ALL) const override;
 
     /// Check if a point is inside the frustrum
-    virtual bool is_inside(const vector_3d &,
-                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_inside(const vector_3d &,
+                           double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Check if a point is outside the frustrum
-    virtual bool is_outside(const vector_3d &,
-                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+    bool is_outside(const vector_3d &,
+                            double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Return the surface bit a point belongs to
-    virtual face_identifier on_surface(const vector_3d &,
+    face_identifier on_surface(const vector_3d &,
                                        const face_identifier & a_surface_mask = face_identifier::face_bits_any(),
-                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                       double a_skin = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Compute the normal to the surface of the furstrum
-    virtual vector_3d get_normal_on_surface (const vector_3d & position_,
-                                             const face_identifier & ) const;
+    vector_3d get_normal_on_surface (const vector_3d & position_,
+                                             const face_identifier & ) const override;
 
     /// Find the intercept point with a face of the frustrum
-    virtual bool find_intercept(const vector_3d & from_,
+    bool find_intercept(const vector_3d & from_,
                                 const vector_3d & direction_,
                                 face_intercept_info & intercept_,
-                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const;
+                                double skin_ = GEOMTOOLS_PROPER_TOLERANCE) const override;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
 
     /// \brief 3D rendering options
     enum wall_wires_rendering_option_type {
@@ -164,8 +164,8 @@ namespace geomtools {
     };
 
     /// Generate a list of polylines representing the contour of the shape (for display clients)
-    virtual void generate_wires_self(wires_type & wires_,
-                                     uint32_t options_ = 0) const;
+    void generate_wires_self(wires_type & wires_,
+                                     uint32_t options_ = 0) const override;
 
     /// Convert the wall to a tessellated solid
     void convert_to_tessellated(tessellated_solid &) const;
@@ -173,7 +173,7 @@ namespace geomtools {
   protected:
 
     /// Build bounding data
-    virtual void _build_bounding_data();
+    void _build_bounding_data() override;
 
     /// Set default attributes
     void _set_defaults();

--- a/source/bxmaterials/include/materials/element.h
+++ b/source/bxmaterials/include/materials/element.h
@@ -156,7 +156,7 @@ namespace materials {
     explicit element(const char * name_, const  char * symbol_ = "", unsigned int build_flags_ = 0);
 
     /// Destructor
-    virtual ~element();
+    ~element() override;
 
     /// Return true if the element is built by isotopic composition
     bool is_built_by_isotopic_composition () const;
@@ -239,10 +239,10 @@ namespace materials {
     void reset();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_  = std::clog,
+    void tree_dump(std::ostream & out_  = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_ = false) const;
+                            bool inherit_ = false) const override;
 
   protected:
 

--- a/source/bxmaterials/include/materials/isotope.h
+++ b/source/bxmaterials/include/materials/isotope.h
@@ -120,10 +120,10 @@ namespace materials {
       bool operator==(const id &) const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_         = std::clog,
+      void tree_dump(std::ostream & out_         = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_          = false) const;
+                             bool inherit_          = false) const override;
 
     private:
 
@@ -159,10 +159,10 @@ namespace materials {
       //! Default constructor
       record_type();
       //! Smart print
-      virtual void tree_dump(std::ostream & out_         = std::clog,
+      void tree_dump(std::ostream & out_         = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
     public:
 
@@ -357,7 +357,7 @@ namespace materials {
                      unsigned int build_flags_ = 0);
 
     //! Destructor
-    virtual ~isotope();
+    ~isotope() override;
 
     //! Return true if isotope is valid, false either
     bool is_valid() const;
@@ -528,10 +528,10 @@ namespace materials {
     void reset();
 
     //! Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
 
     //! Compute the atomic electron binding energy for ion with given Z
     static double compute_electron_binding_energy(int z_);

--- a/source/bxmaterials/include/materials/manager.h
+++ b/source/bxmaterials/include/materials/manager.h
@@ -59,7 +59,7 @@ namespace materials {
     manager();
 
     /// Destructor
-    virtual ~manager();
+    ~manager() override;
 
     /// Check initialization flag
     bool is_initialized() const;
@@ -137,10 +137,10 @@ namespace materials {
     void unlock();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_    = std::clog,
+    void tree_dump(std::ostream & out_    = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
 
     /// Set logging priority
     void set_logging_priority(datatools::logger::priority);

--- a/source/bxmaterials/include/materials/material.h
+++ b/source/bxmaterials/include/materials/material.h
@@ -170,7 +170,7 @@ namespace materials {
     explicit material(const char * name_);
 
     /// Destructor
-    virtual ~material();
+    ~material() override;
 
     /// Check if the material is composed by mean Z and A
     bool is_composed_by_mean_z_a() const;
@@ -275,10 +275,10 @@ namespace materials {
     void reset();
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_  = std::clog,
+    void tree_dump(std::ostream & out_  = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 

--- a/source/bxmaterials/include/materials/refractive_index.h
+++ b/source/bxmaterials/include/materials/refractive_index.h
@@ -60,7 +60,7 @@ namespace materials {
     refractive_index();
 
     /// Destructor
-    virtual ~refractive_index();
+    ~refractive_index() override;
 
     /// Check the refractive index evaluation mode
     bool is_eval_n() const;
@@ -127,24 +127,24 @@ namespace materials {
     double compute_abbe_number_e() const;
 
     /// Check if a domain of definition is set
-    virtual bool has_explicit_domain_of_definition() const;
+    bool has_explicit_domain_of_definition() const override;
 
     /// Check if a value is in the domain of definition
-    virtual bool is_in_domain_of_definition(const double x_) const;
+    bool is_in_domain_of_definition(const double x_) const override;
 
     /// Check initialization status
-    bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Initialize from properties
     void initialize(const datatools::properties & config_,
-                    const mygsl::unary_function_dict_type & /* functors_ */);
+                    const mygsl::unary_function_dict_type & /* functors_ */) override;
 
     /// Reset
-    void reset();
+    void reset() override;
 
   protected:
 
-    virtual double _eval(double) const;
+    double _eval(double) const override;
 
     double _eval_n(double) const;
 

--- a/source/bxmctools/include/mctools/base_step_hit.h
+++ b/source/bxmctools/include/mctools/base_step_hit.h
@@ -332,17 +332,17 @@ namespace mctools {
      * - start time is set
      * - start position is set
      */
-    virtual bool is_valid() const;
+    bool is_valid() const override;
 
     /// Reset/invalidate the internal structure of the hit
-    virtual void invalidate();
+    void invalidate() override;
 
 
     /// Default constructor
     base_step_hit() = default;
 
     // Destructor
-    virtual ~base_step_hit() = default;
+    ~base_step_hit() override = default;
 
     // Copy constructor
     base_step_hit(const base_step_hit &) = default;
@@ -360,13 +360,13 @@ namespace mctools {
     void reset();
 
     /// Reset/invalidate the internal structure of the hit
-    virtual void clear();
+    void clear() override;
 
     /// \deprecated Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
     
     //!
     //! Supported options:

--- a/source/bxmctools/include/mctools/base_step_hit_processor.h
+++ b/source/bxmctools/include/mctools/base_step_hit_processor.h
@@ -86,7 +86,7 @@ namespace mctools {
     base_step_hit_processor();
 
     /// Destructor
-    virtual ~base_step_hit_processor();
+    ~base_step_hit_processor() override;
 
     const std::string & get_hit_category() const;
 
@@ -138,10 +138,10 @@ namespace mctools {
                          simulated_data::hit_collection_type & plain_hits_);
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
     /// Return the logging priority threshold
     datatools::logger::priority get_logging_priority() const;
@@ -207,19 +207,19 @@ namespace mctools {
     push_all_step_hit_processor();
 
     /// Destructor
-    virtual ~push_all_step_hit_processor();
+    ~push_all_step_hit_processor() override;
 
     /// Main setup routine
-    virtual void initialize(const ::datatools::properties & config_,
-                            ::datatools::service_manager & service_mgr_);
+    void initialize(const ::datatools::properties & config_,
+                            ::datatools::service_manager & service_mgr_) override;
 
     /// Main processing routine :
-    virtual void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
-                         ::mctools::simulated_data::hit_handle_collection_type & handle_hits_);
+    void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
+                         ::mctools::simulated_data::hit_handle_collection_type & handle_hits_) override;
 
     /// Main processing routine :
-    virtual void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
-                         ::mctools::simulated_data::hit_collection_type & plain_hits_);
+    void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
+                         ::mctools::simulated_data::hit_collection_type & plain_hits_) override;
 
     void set_visu_highlighted_hits(bool);
 
@@ -254,19 +254,19 @@ namespace mctools {
     kill_all_step_hit_processor();
 
     /// Destructor
-    virtual ~kill_all_step_hit_processor();
+    ~kill_all_step_hit_processor() override;
 
     /// Main setup routine
-    virtual void initialize(const ::datatools::properties & config_,
-                            ::datatools::service_manager & service_mgr_);
+    void initialize(const ::datatools::properties & config_,
+                            ::datatools::service_manager & service_mgr_) override;
 
     /// Main processing routine :
-    virtual void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
-                         ::mctools::simulated_data::hit_handle_collection_type & handle_hits_);
+    void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
+                         ::mctools::simulated_data::hit_handle_collection_type & handle_hits_) override;
 
     /// Main processing routine :
-    virtual void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
-                         ::mctools::simulated_data::hit_collection_type & plain_hits_);
+    void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
+                         ::mctools::simulated_data::hit_collection_type & plain_hits_) override;
 
     // Registration macro :
     MCTOOLS_STEP_HIT_PROCESSOR_REGISTRATION_INTERFACE(kill_all_step_hit_processor)

--- a/source/bxmctools/include/mctools/biasing/point_of_interest.h
+++ b/source/bxmctools/include/mctools/biasing/point_of_interest.h
@@ -139,10 +139,10 @@ namespace mctools {
       void initialize(const datatools::properties & config_, const geomtools::manager * geomgr_ = 0);
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_         = std::clog,
+      void tree_dump(std::ostream & out_         = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
       /// Check if a linear trajectory coming from a given source with a given direction traverse the sphere
       bool hit(const geomtools::vector_3d & source_, const geomtools::vector_3d & direction_) const;

--- a/source/bxmctools/include/mctools/biasing/primary_event_bias.h
+++ b/source/bxmctools/include/mctools/biasing/primary_event_bias.h
@@ -160,7 +160,7 @@ namespace mctools {
       primary_event_bias();
 
       /// Destructor
-      virtual ~primary_event_bias();
+      ~primary_event_bias() override;
 
       /// Set the geometry manager
       void set_geometry_manager(const geomtools::manager &);
@@ -249,10 +249,10 @@ namespace mctools {
                    biasing_info & info_);
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_         = std::clog,
+      void tree_dump(std::ostream & out_         = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
       /// Draw
       void draw(const geomtools::vector_3d & vertex_,

--- a/source/bxmctools/include/mctools/calorimeter_step_hit_processor.h
+++ b/source/bxmctools/include/mctools/calorimeter_step_hit_processor.h
@@ -69,19 +69,19 @@ namespace mctools {
     calorimeter_step_hit_processor();
 
     /// Destructor
-    virtual ~calorimeter_step_hit_processor();
+    ~calorimeter_step_hit_processor() override;
 
     /// Main setup routine
-    virtual void initialize(const ::datatools::properties & config_,
-                            ::datatools::service_manager & service_mgr_);
+    void initialize(const ::datatools::properties & config_,
+                            ::datatools::service_manager & service_mgr_) override;
 
     /// Main processing routine :
-    virtual void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
-                         ::mctools::simulated_data::hit_handle_collection_type & handle_hits_);
+    void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
+                         ::mctools::simulated_data::hit_handle_collection_type & handle_hits_) override;
 
     /// Main processing routine :
-    virtual void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
-                         ::mctools::simulated_data::hit_collection_type & plain_hits_);
+    void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
+                         ::mctools::simulated_data::hit_collection_type & plain_hits_) override;
 
     /** Check if a step hit in a candidate for clusterization within
      * the proposed scintillation hit
@@ -96,7 +96,7 @@ namespace mctools {
     void tree_dump(std::ostream & out_ = std::clog,
                    const std::string & title_ = "" ,
                    const std::string & indent_ = "",
-                   bool inherit_ = false) const;
+                   bool inherit_ = false) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);

--- a/source/bxmctools/include/mctools/digitization/sampled_signal.h
+++ b/source/bxmctools/include/mctools/digitization/sampled_signal.h
@@ -91,10 +91,10 @@ namespace mctools {
       sampled_signal(const double sampling_frequency_, const std::size_t nsamples_, const int32_t value_ = INVALID_SAMPLE);
 
       //! Destructor
-      virtual ~sampled_signal();
+      ~sampled_signal() override;
 
       //! Check validity
-      virtual bool is_valid() const;
+      bool is_valid() const override;
 
       //! Check if sampling frequency is set
       bool has_sampling_frequency() const;
@@ -205,10 +205,10 @@ namespace mctools {
       void set_overflow_sample(const uint32_t index_, const bool update_ = false);
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_         = std::clog,
+      void tree_dump(std::ostream & out_         = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
       //! Update internal data
       void update();

--- a/source/bxmctools/include/mctools/digitization/simple_linear_adc.h
+++ b/source/bxmctools/include/mctools/digitization/simple_linear_adc.h
@@ -57,7 +57,7 @@ namespace mctools {
       simple_linear_adc();
 
       //! Destructor
-      virtual ~simple_linear_adc();
+      ~simple_linear_adc() override;
 
       //! Set the low voltage reference value
       void set_v_ref_low(const double);
@@ -123,7 +123,7 @@ namespace mctools {
       double compute_sampled_voltage(int32_t channel_, bool ignore_out_ = false) const;
 
       //! Quantize
-      virtual int32_t quantize(const double vinput_) const;
+      int32_t quantize(const double vinput_) const override;
 
       //! Return the minimum channel
       int32_t get_min_channel() const;
@@ -138,10 +138,10 @@ namespace mctools {
       double get_voltage_resolution() const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_         = std::clog,
+      void tree_dump(std::ostream & out_         = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
       //! Reflection interface
       DR_CLASS_RTTI()

--- a/source/bxmctools/include/mctools/fluence_step_hit_processor.h
+++ b/source/bxmctools/include/mctools/fluence_step_hit_processor.h
@@ -63,25 +63,25 @@ namespace mctools {
     fluence_step_hit_processor();
 
     /// Destructor
-    virtual ~fluence_step_hit_processor();
+    ~fluence_step_hit_processor() override;
 
     /// Main setup routine
-    virtual void initialize(const ::datatools::properties & config_,
-                            ::datatools::service_manager & service_mgr_);
+    void initialize(const ::datatools::properties & config_,
+                            ::datatools::service_manager & service_mgr_) override;
 
     /// Main processing routine :
-    virtual void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
-                         ::mctools::simulated_data::hit_handle_collection_type & handle_hits_);
+    void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
+                         ::mctools::simulated_data::hit_handle_collection_type & handle_hits_) override;
 
     /// Main processing routine :
-    virtual void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
-                         ::mctools::simulated_data::hit_collection_type & plain_hits_);
+    void process(const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type & base_step_hits_,
+                         ::mctools::simulated_data::hit_collection_type & plain_hits_) override;
 
     /// Smart print
     void tree_dump(std::ostream & out_ = std::clog,
                    const std::string & title_ = "" ,
                    const std::string & indent_ = "",
-                   bool inherit_ = false) const;
+                   bool inherit_ = false) const override;
 
     /// OCD support
     static void init_ocd(datatools::object_configuration_description &);

--- a/source/bxmctools/include/mctools/g4/base_physics_constructor.h
+++ b/source/bxmctools/include/mctools/g4/base_physics_constructor.h
@@ -68,7 +68,7 @@ namespace mctools {
       base_physics_constructor();
 
       /// Desctructor
-      virtual ~base_physics_constructor();
+      ~base_physics_constructor() override;
 
       /// Initialization from a set of configuration properties and a dictionary of physics constructors
       virtual void initialize(const datatools::properties & config_,
@@ -83,10 +83,10 @@ namespace mctools {
       // G4 mandatory interface: construct particle and physics
 
       /// Construct the Geant4 particle list
-      virtual void ConstructParticle(); // Default empty implementation
+      void ConstructParticle() override; // Default empty implementation
 
       /// Construct the Geant4 processes list
-      virtual void ConstructProcess(); // Default empty implementation
+      void ConstructProcess() override; // Default empty implementation
 
       /// Check if the constructor has a mother physics list
       bool has_mother_physics_list() const;
@@ -95,10 +95,10 @@ namespace mctools {
       const physics_list & get_mother_physics_list() const;
 
       /// Smart print
-      virtual void tree_dump (std::ostream      & out_    = std::clog,
+      void tree_dump (std::ostream      & out_    = std::clog,
                               const std::string & title_  = "",
                               const std::string & indent_ = "",
-                              bool inherit_               = false) const;
+                              bool inherit_               = false) const override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/detector_construction.h
+++ b/source/bxmctools/include/mctools/g4/detector_construction.h
@@ -83,7 +83,7 @@ namespace mctools {
       detector_construction(manager & mgr_);
 
       /// Destructor
-      virtual ~detector_construction();
+      ~detector_construction() override;
 
       /// Check initialization flag
       bool is_initialized() const;
@@ -138,7 +138,7 @@ namespace mctools {
       void set_emfield_geom_plugin_name(const std::string & fpn_);
 
       /// G4 interface
-      G4VPhysicalVolume * Construct();
+      G4VPhysicalVolume * Construct() override;
 
       /** Generate the GDML file from the geometry manager */
       void write_tmp_gdml_file();

--- a/source/bxmctools/include/mctools/g4/electromagnetic_field.h
+++ b/source/bxmctools/include/mctools/g4/electromagnetic_field.h
@@ -102,7 +102,7 @@ namespace mctools {
       electromagnetic_field();
 
       /// Destructor
-      virtual ~electromagnetic_field();
+      ~electromagnetic_field() override;
 
       /// Initialization
       void initialize(const datatools::properties & config_);
@@ -119,10 +119,10 @@ namespace mctools {
       // G4 interface:
 
       /// Return the field value at given position/time
-      void GetFieldValue(const double position_[4], double * em_field_) const;
+      void GetFieldValue(const double position_[4], double * em_field_) const override;
 
       /// Check if the field changes the energy
-      virtual G4bool DoesFieldChangeEnergy() const;
+      G4bool DoesFieldChangeEnergy() const override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/em_field_equation_of_motion.h
+++ b/source/bxmctools/include/mctools/g4/em_field_equation_of_motion.h
@@ -74,16 +74,16 @@ namespace mctools {
       em_field_equation_of_motion(G4Field * field_);
 
       /// Destructor
-      virtual ~em_field_equation_of_motion();
+      ~em_field_equation_of_motion() override;
 
       /// Given the value of the mixed fields (magnetic + electric), this method
       /// calculates the value of the derivative dydx for position, momentum and
       //  spin of the particle.
       /// Derivatives are defined as:
       ///   dr/ds, dp/ds, dt/ds, dSpin/ds
-      virtual void EvaluateRhsGivenB(const G4double y_[],
+      void EvaluateRhsGivenB(const G4double y_[],
                                      const G4double field_[6],
-                                     G4double dydx_[]) const;
+                                     G4double dydx_[]) const override;
 
       /// Set the charge, momentum and mass of the current particle
       /// used to set the equation's coefficients
@@ -91,7 +91,7 @@ namespace mctools {
       /// Signature has changed for some Geant 4.10.X version (see below)
       void SetChargeMomentumMass(G4double particle_charge_, // in e+ units
                                  G4double particle_momentum_,
-                                 G4double particle_mass_);
+                                 G4double particle_mass_) override;
       
 #if G4VERSION_NUMBER >= 1000
       // New signature for this virtual method in Geant 4.10.X

--- a/source/bxmctools/include/mctools/g4/em_field_g4_stuff.h
+++ b/source/bxmctools/include/mctools/g4/em_field_g4_stuff.h
@@ -75,7 +75,7 @@ namespace mctools {
       em_field_g4_stuff();
 
       /// Destructor
-      virtual ~em_field_g4_stuff();
+      ~em_field_g4_stuff() override;
 
       /// Initialization
       void initialize();
@@ -160,10 +160,10 @@ namespace mctools {
       G4FieldManager * grab_field_manager();
 
       /// Smart print
-      virtual void tree_dump(std::ostream      & out_    = std::clog,
+      void tree_dump(std::ostream      & out_    = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/em_physics_constructor.h
+++ b/source/bxmctools/include/mctools/g4/em_physics_constructor.h
@@ -82,26 +82,26 @@ namespace mctools {
       em_physics_constructor();
 
       /// Destructor
-      virtual ~em_physics_constructor();
+      ~em_physics_constructor() override;
 
       /// Initialization
-      virtual void initialize(const datatools::properties & config_,
-                              physics_constructor_dict_type & dict_);
+      void initialize(const datatools::properties & config_,
+                              physics_constructor_dict_type & dict_) override;
 
       /// Reset
-      virtual void reset();
+      void reset() override;
 
       /// Smart print
-      virtual void tree_dump(std::ostream      & out_    = std::clog,
+      void tree_dump(std::ostream      & out_    = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
       /// Particles construction Geant4 interface :
-      virtual void ConstructParticle();
+      void ConstructParticle() override;
 
       /// Processes construction Geant4 interface :
-      virtual void ConstructProcess();
+      void ConstructProcess() override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/event_action.h
+++ b/source/bxmctools/include/mctools/g4/event_action.h
@@ -83,7 +83,7 @@ namespace mctools {
       event_action(run_action & a_run_action, const detector_construction & a_dctor);
 
       /// Destructor
-      virtual ~event_action();
+      ~event_action() override;
 
       /// Initialization from a set of configuration parameters
       void initialize(const ::datatools::properties & a_config);
@@ -93,9 +93,9 @@ namespace mctools {
 
       // Geant4 interface :
 
-      void BeginOfEventAction(const G4Event *);
+      void BeginOfEventAction(const G4Event *) override;
 
-      void EndOfEventAction(const G4Event *);
+      void EndOfEventAction(const G4Event *) override;
 
     private:
 

--- a/source/bxmctools/include/mctools/g4/magnetic_field.h
+++ b/source/bxmctools/include/mctools/g4/magnetic_field.h
@@ -100,7 +100,7 @@ namespace mctools {
       magnetic_field ();
 
       /// Destructor
-      virtual ~magnetic_field ();
+      ~magnetic_field () override;
 
       /// Initialization
       void initialize (const datatools::properties & config_);
@@ -116,7 +116,7 @@ namespace mctools {
 
       // G4 interface:
       void GetFieldValue (const double position_[3],
-                          double * b_field_) const;
+                          double * b_field_) const override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/neutrons_physics_constructor.h
+++ b/source/bxmctools/include/mctools/g4/neutrons_physics_constructor.h
@@ -33,26 +33,26 @@ namespace mctools {
       neutrons_physics_constructor();
 
       /// Destructor
-      virtual ~neutrons_physics_constructor();
+      ~neutrons_physics_constructor() override;
 
       /// Initialization
-      virtual void initialize(const datatools::properties & config_,
-                              physics_constructor_dict_type & dict_);
+      void initialize(const datatools::properties & config_,
+                              physics_constructor_dict_type & dict_) override;
 
       /// Reset
-      virtual void reset();
+      void reset() override;
 
       /// Smart print
-      virtual void tree_dump(std::ostream      & out_    = std::clog,
+      void tree_dump(std::ostream      & out_    = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
       /// Particles construction (Geant4 interface)
-      virtual void ConstructParticle();
+      void ConstructParticle() override;
 
       /// Processes construction (Geant4 interface)
-      virtual void ConstructProcess();
+      void ConstructProcess() override;
 
       /// OCD support
       static void init_ocd(datatools::object_configuration_description &);

--- a/source/bxmctools/include/mctools/g4/particles_physics_constructor.h
+++ b/source/bxmctools/include/mctools/g4/particles_physics_constructor.h
@@ -29,21 +29,21 @@ namespace mctools {
 
       particles_physics_constructor ();
 
-      virtual ~particles_physics_constructor ();
+      ~particles_physics_constructor () override;
 
-      virtual void initialize (const datatools::properties & config_,
-                               physics_constructor_dict_type & dict_);
+      void initialize (const datatools::properties & config_,
+                               physics_constructor_dict_type & dict_) override;
 
-      virtual void reset ();
+      void reset () override;
 
-      virtual void tree_dump (std::ostream      & out_    = std::clog,
+      void tree_dump (std::ostream      & out_    = std::clog,
                               const std::string & title_  = "",
                               const std::string & indent_ = "",
-                              bool inherit_               = false) const;
+                              bool inherit_               = false) const override;
 
 
       /// Particles construction Geant4 interface :
-      virtual void ConstructParticle ();
+      void ConstructParticle () override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/physics_list.h
+++ b/source/bxmctools/include/mctools/g4/physics_list.h
@@ -119,7 +119,7 @@ namespace mctools {
       physics_list();
 
       /// Destructor
-      virtual ~physics_list();
+      ~physics_list() override;
 
       /// Intialization from a set of configuration parameters
       void initialize(const datatools::properties & config_);
@@ -128,21 +128,21 @@ namespace mctools {
       void reset();
 
       /// Smart print
-      virtual void tree_dump(std::ostream      & out_    = std::clog,
+      void tree_dump(std::ostream      & out_    = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
       // G4 mandatory interface: construct particle and physics
 
       /// Construct Geant4 particles
-      virtual void ConstructParticle();
+      void ConstructParticle() override;
 
       /// Construct Geant4 processes
-      virtual void ConstructProcess();
+      void ConstructProcess() override;
 
       /// Set the cuts associated to particles
-      virtual void SetCuts();
+      void SetCuts() override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/physics_list_utils.h
+++ b/source/bxmctools/include/mctools/g4/physics_list_utils.h
@@ -69,19 +69,19 @@ namespace mctools {
     /// \brief Physics constructor proxy class with weak referencing
     struct physics_constructor_proxy : public G4VPhysicsConstructor {
       physics_constructor_proxy(base_physics_constructor & pc_);
-      virtual ~physics_constructor_proxy();
-      virtual void ConstructParticle();
-      virtual void ConstructProcess();
+      ~physics_constructor_proxy() override;
+      void ConstructParticle() override;
+      void ConstructProcess() override;
       base_physics_constructor * pc; //!< Reference to a mctools physics constructor object
     };
 
     /// \brief Physics list proxy class with weak referencing
     struct physics_list_proxy : public G4VModularPhysicsList {
       physics_list_proxy(G4VModularPhysicsList & pl_);
-      virtual ~physics_list_proxy();
-      virtual void ConstructParticle();
-      virtual void ConstructProcess();
-      virtual void SetCuts();
+      ~physics_list_proxy() override;
+      void ConstructParticle() override;
+      void ConstructProcess() override;
+      void SetCuts() override;
       G4VModularPhysicsList * pl; //!< Reference to a Geant4 physics list object
     };
 

--- a/source/bxmctools/include/mctools/g4/primary_generator.h
+++ b/source/bxmctools/include/mctools/g4/primary_generator.h
@@ -93,7 +93,7 @@ namespace mctools {
       primary_generator();
 
       /// Destructor
-      virtual ~primary_generator();
+      ~primary_generator() override;
 
       /// Initialization
       void initialize(const datatools::properties & config_);
@@ -105,7 +105,7 @@ namespace mctools {
       std::string get_g4_particle_name_from_genbb_particle(const ::genbb::primary_particle & p_) const;
 
       ///  Geant4 interface for primary event generation
-      void GeneratePrimaries(G4Event *);
+      void GeneratePrimaries(G4Event *) override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/processes/em_extra_models.h
+++ b/source/bxmctools/include/mctools/g4/processes/em_extra_models.h
@@ -40,7 +40,7 @@ namespace mctools {
         em_extra_model();
 
         /// Destructor
-        virtual ~em_extra_model();
+        ~em_extra_model() override;
 
         /// Check initialization
         bool is_initialized() const;
@@ -134,10 +134,10 @@ namespace mctools {
         static bool validate_g4_model_type_id(std::string & model_type_id_);
 
         /// Smart print
-        virtual void tree_dump(std::ostream      & out_    = std::clog,
+        void tree_dump(std::ostream      & out_    = std::clog,
                                const std::string & title_  = "",
                                const std::string & indent_ = "",
-                               bool inherit_               = false) const;
+                               bool inherit_               = false) const override;
 
       public:
 

--- a/source/bxmctools/include/mctools/g4/processes/em_model_factory.h
+++ b/source/bxmctools/include/mctools/g4/processes/em_model_factory.h
@@ -48,7 +48,7 @@ namespace mctools {
         em_model_factory();
 
         /// Destructor
-        ~em_model_factory();
+        virtual ~em_model_factory();
 
         /// Check initialization
         bool is_initialized() const;

--- a/source/bxmctools/include/mctools/g4/region_tools.h
+++ b/source/bxmctools/include/mctools/g4/region_tools.h
@@ -51,7 +51,7 @@ namespace mctools {
       region_info();
 
       /// Destructor
-      virtual ~region_info();
+      ~region_info() override;
 
       /// Check initialization flag
       bool is_initialized() const;
@@ -82,10 +82,10 @@ namespace mctools {
       std::set<std::string> & grab_logical_ids();
 
       /// Smart print
-      virtual void tree_dump(std::ostream      & out_    = std::clog,
+      void tree_dump(std::ostream      & out_    = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
     private:
 
@@ -106,7 +106,7 @@ namespace mctools {
       regions_setup();
 
       /// Destructor
-      ~regions_setup();
+      ~regions_setup() override;
 
       /// Initialize
       void initialize(const datatools::properties &);
@@ -133,10 +133,10 @@ namespace mctools {
       // Fetch a list of regexps on volume names belonging to this region:
       
       /// Smart print
-      virtual void tree_dump(std::ostream      & out_    = std::clog,
+      void tree_dump(std::ostream      & out_    = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
       // Validate for Geant4...
       // static bool validate_for_geant4(const region_infos_dict_type & region_infos_);

--- a/source/bxmctools/include/mctools/g4/run_action.h
+++ b/source/bxmctools/include/mctools/g4/run_action.h
@@ -149,7 +149,7 @@ namespace mctools {
       run_action(manager & a_mgr);
 
       /// Destructor
-      virtual ~run_action();
+      ~run_action() override;
 
       /// Register the event action
       void register_event_action(event_action &);
@@ -167,10 +167,10 @@ namespace mctools {
       void store_data(const mctools::simulated_data & esd_);
 
       /// Geant4 BeginOfRunAction mandatory interface
-      void BeginOfRunAction(const G4Run *);
+      void BeginOfRunAction(const G4Run *) override;
 
       /// Geant4 EndOfRunAction mandatory interface
-      void EndOfRunAction(const G4Run *);
+      void EndOfRunAction(const G4Run *) override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/sensitive_detector.h
+++ b/source/bxmctools/include/mctools/g4/sensitive_detector.h
@@ -162,13 +162,13 @@ namespace mctools {
       sensitive_detector(const std::string & name_);
 
       /// Desctructor
-      virtual ~sensitive_detector();
+      ~sensitive_detector() override;
 
       /// Configure the sensitive detector from a container of parameters
       void configure(const datatools::properties & config_);
 
       /// Terminate
-      virtual void clear();
+      void clear() override;
 
       /// Smart print
       virtual void tree_dump(std::ostream      & out_    = std::clog,
@@ -177,13 +177,13 @@ namespace mctools {
                               bool inherit_               = false) const;
 
       /// Initialize the Geant4 collection of hits (Geant4 interface)
-      virtual void Initialize(G4HCofThisEvent *);
+      void Initialize(G4HCofThisEvent *) override;
 
       /// Terminate the Geant4 collection of hits (Geant4 interface)
-      virtual void EndOfEvent(G4HCofThisEvent *);
+      void EndOfEvent(G4HCofThisEvent *) override;
 
       /// Process the current Geant4 step (Geant4 interface)
-      virtual G4bool ProcessHits(G4Step *, G4TouchableHistory *);
+      G4bool ProcessHits(G4Step *, G4TouchableHistory *) override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/sensitive_hit.h
+++ b/source/bxmctools/include/mctools/g4/sensitive_hit.h
@@ -42,7 +42,7 @@ namespace mctools {
       sensitive_hit() = default;
 
       /// Destructor
-      virtual ~sensitive_hit() = default;
+      ~sensitive_hit() override = default;
 
       /// Copy Constructor
       sensitive_hit(const sensitive_hit &) = default;

--- a/source/bxmctools/include/mctools/g4/sensitive_hit_collection.h
+++ b/source/bxmctools/include/mctools/g4/sensitive_hit_collection.h
@@ -39,7 +39,7 @@ namespace mctools {
 
       sensitive_hit_collection (G4String a_detector_name, G4String a_collection_name);
 
-      virtual ~sensitive_hit_collection () = default;
+      ~sensitive_hit_collection () override = default;
 
       sensitive_hit_collection(const sensitive_hit_collection&) = default;
       
@@ -57,9 +57,9 @@ namespace mctools {
 
       // G4VHitsCollection Interface :
 
-      virtual G4VHit * GetHit(size_t) const;
+      G4VHit * GetHit(size_t) const override;
 
-      virtual size_t GetSize() const;
+      size_t GetSize() const override;
 
     protected:
 

--- a/source/bxmctools/include/mctools/g4/simulation_ctrl.h
+++ b/source/bxmctools/include/mctools/g4/simulation_ctrl.h
@@ -46,7 +46,7 @@ class simulation_ctrl : public loggable_support {
   simulation_ctrl(manager& simulation_manager_, uint32_t max_counts_ = 0);
 
   /// Destructor
-  ~simulation_ctrl();
+  ~simulation_ctrl() override;
 
   /// Set the Geant4 simulation manager
   void set_simulation_manager(manager & simulation_manager_);

--- a/source/bxmctools/include/mctools/g4/stacking_action.h
+++ b/source/bxmctools/include/mctools/g4/stacking_action.h
@@ -49,19 +49,19 @@ namespace mctools {
       stacking_action ();
 
       /// Destructor
-      virtual ~stacking_action ();
+      ~stacking_action () override;
 
       /// Initialize
       void initialize (const datatools::properties & config_);
 
       // Geant4 interface :
-      virtual G4ClassificationOfNewTrack ClassifyNewTrack (const G4Track * track_);
+      G4ClassificationOfNewTrack ClassifyNewTrack (const G4Track * track_) override;
 
       // Geant4 interface :
-      virtual void NewStage ();
+      void NewStage () override;
 
       // Geant4 interface :
-      virtual void PrepareNewEvent ();
+      void PrepareNewEvent () override;
 
     private:
 

--- a/source/bxmctools/include/mctools/g4/stepping_action.h
+++ b/source/bxmctools/include/mctools/g4/stepping_action.h
@@ -49,7 +49,7 @@ namespace mctools {
       stepping_action();
 
       /// Destructor
-      virtual ~stepping_action();
+      ~stepping_action() override;
 
       /// Initialize
       void initialize(const datatools::properties & config_);
@@ -64,7 +64,7 @@ namespace mctools {
       bool is_dumped() const;
 
       /// Main stepping action for the Geant4 interface
-      void UserSteppingAction(const G4Step *);
+      void UserSteppingAction(const G4Step *) override;
 
       /// Convert a Geant4 track status to a printable string
       static std::string g4_track_status_to_label(G4TrackStatus);

--- a/source/bxmctools/include/mctools/g4/stepping_verbose.h
+++ b/source/bxmctools/include/mctools/g4/stepping_verbose.h
@@ -28,13 +28,13 @@ namespace mctools {
       stepping_verbose ();
 
       /// Destructor
-      virtual ~stepping_verbose ();
+      ~stepping_verbose () override;
 
       /// Geant4 interface
-      void StepInfo ();
+      void StepInfo () override;
 
       /// Geant4 interface
-      void TrackingStarted ();
+      void TrackingStarted () override;
 
     };
 

--- a/source/bxmctools/include/mctools/g4/tracking_action.h
+++ b/source/bxmctools/include/mctools/g4/tracking_action.h
@@ -43,16 +43,16 @@ namespace mctools {
       tracking_action();
 
       /// Destructor
-      virtual ~tracking_action();
+      ~tracking_action() override;
 
       /// Initialize from properties
       void initialize(const datatools::properties & config_);
 
       /// Pre-tracking action for the Geant4 interface
-      virtual void PreUserTrackingAction(const G4Track*);
+      void PreUserTrackingAction(const G4Track*) override;
 
       /// Post-tracking action for the Geant4 interface
-      virtual void PostUserTrackingAction(const G4Track*);
+      void PostUserTrackingAction(const G4Track*) override;
 
     };
 

--- a/source/bxmctools/include/mctools/signal/base_signal.h
+++ b/source/bxmctools/include/mctools/signal/base_signal.h
@@ -68,13 +68,13 @@ namespace mctools {
       base_signal(const base_signal &);
 
       //! Destructor
-      virtual ~base_signal();
+      ~base_signal() override;
 
       //! Assignment operator
       base_signal & operator=(const base_signal &);
 
       //! Check signal hit validity
-      virtual bool is_valid() const;
+      bool is_valid() const override;
 
       //! Allow no shape builder
       void set_allow_no_shape_builder(bool a_);
@@ -249,10 +249,10 @@ namespace mctools {
       const datatools::multi_properties & get_private_shapes_config() const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_         = std::clog,
+      void tree_dump(std::ostream & out_         = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
       //! Compute shape
       double compute_shape(double time_) const;

--- a/source/bxmctools/include/mctools/signal/multi_signal_shape.h
+++ b/source/bxmctools/include/mctools/signal/multi_signal_shape.h
@@ -58,20 +58,20 @@ namespace mctools {
       multi_signal_shape();
 
       //! Destructor
-      virtual ~multi_signal_shape();
+      ~multi_signal_shape() override;
 
       //! Check the validity
       bool is_valid() const;
 
       //! Check initialization status
-      virtual bool is_initialized() const;
+      bool is_initialized() const override;
 
       //! Initialization
-      virtual void initialize(const datatools::properties & config_,
-                              const mygsl::unary_function_dict_type & functors_);
+      void initialize(const datatools::properties & config_,
+                              const mygsl::unary_function_dict_type & functors_) override;
 
       //! Reset
-      virtual void reset();
+      void reset() override;
 
       //! Remove a component signal by index
       void remove(const std::size_t index_);
@@ -92,22 +92,22 @@ namespace mctools {
       std::size_t get_number_of_components() const;
 
       //! Check if the function has an explicit domain of definition (default: false)
-      virtual bool has_explicit_domain_of_definition() const;
+      bool has_explicit_domain_of_definition() const override;
 
       //! Check if a value is in the explicit domain of definition (default: true)
-      virtual bool is_in_domain_of_definition(double x_) const;
+      bool is_in_domain_of_definition(double x_) const override;
 
       //! The minimum bound of the non-zero domain (default is minus infinity)
-      virtual double get_non_zero_domain_min() const;
+      double get_non_zero_domain_min() const override;
 
       //! The maximum bound of the non-zero domain (default is plus infinity)
-      virtual double get_non_zero_domain_max() const;
+      double get_non_zero_domain_max() const override;
 
       //! Smart printing
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     protected:
 
@@ -115,7 +115,7 @@ namespace mctools {
       void _set_defaults();
 
       //! Evaluation from parameters
-      double _eval(double x_) const;
+      double _eval(double x_) const override;
 
     private:
 

--- a/source/bxmctools/include/mctools/signal/signal_data.h
+++ b/source/bxmctools/include/mctools/signal/signal_data.h
@@ -66,7 +66,7 @@ namespace mctools {
       signal_data();
 
       /// Destructor
-      virtual ~signal_data();
+      ~signal_data() override;
 
       /// Get a reference to the non mutable collection of auxiliary properties
       const datatools::properties & get_auxiliaries() const;
@@ -119,10 +119,10 @@ namespace mctools {
       void reset();
 
       /// Smart print
-      virtual void tree_dump(std::ostream & out_         = std::clog,
+      void tree_dump(std::ostream & out_         = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
     private:
 

--- a/source/bxmctools/include/mctools/signal/signal_shape_builder.h
+++ b/source/bxmctools/include/mctools/signal/signal_shape_builder.h
@@ -71,7 +71,7 @@ namespace mctools {
       signal_shape_builder();
 
       //! Destructor
-      ~signal_shape_builder();
+      ~signal_shape_builder() override;
 
       //! Return the logging priority
       datatools::logger::priority get_logging_priority() const;
@@ -169,10 +169,10 @@ namespace mctools {
       void build_list_of_functors(std::set<std::string> &) const;
 
       //! Smart print
-      virtual void tree_dump(std::ostream & out_         = std::clog,
+      void tree_dump(std::ostream & out_         = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
     private:
 

--- a/source/bxmctools/include/mctools/signal/triangle_gate_signal_shape.h
+++ b/source/bxmctools/include/mctools/signal/triangle_gate_signal_shape.h
@@ -78,17 +78,17 @@ namespace mctools {
       triangle_gate_signal_shape();
 
       //! Destructor
-      virtual ~triangle_gate_signal_shape();
+      ~triangle_gate_signal_shape() override;
 
       //! Initialization
-      virtual void initialize(const datatools::properties & config_,
-                              const mygsl::unary_function_dict_type & functors_);
+      void initialize(const datatools::properties & config_,
+                              const mygsl::unary_function_dict_type & functors_) override;
 
       //! Reset
-      virtual void reset();
+      void reset() override;
 
       //! Check initialization status
-      virtual bool is_initialized() const;
+      bool is_initialized() const override;
 
       //! Set the polarity of the signal
       void set_polarity(polarity_type);
@@ -142,19 +142,19 @@ namespace mctools {
       double get_tpeak() const;
 
       //! The minimum bound of the non-zero domain (default is minus infinity)
-      virtual double get_non_zero_domain_min() const;
+      double get_non_zero_domain_min() const override;
 
       //! The maximum bound of the non-zero domain (default is plus infinity)
-      virtual double get_non_zero_domain_max() const;
+      double get_non_zero_domain_max() const override;
 
       //! Return the width of the signal
       double get_duration() const;
 
       //! Smart printing
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     protected:
 
@@ -165,7 +165,7 @@ namespace mctools {
       void _compute_parameters();
 
       //! Evaluation from parameters
-      double _eval(double t_) const;
+      double _eval(double t_) const override;
 
     private:
 

--- a/source/bxmctools/include/mctools/signal/triangle_signal_shape.h
+++ b/source/bxmctools/include/mctools/signal/triangle_signal_shape.h
@@ -79,17 +79,17 @@ namespace mctools {
       triangle_signal_shape();
 
       //! Destructor
-      virtual ~triangle_signal_shape();
+      ~triangle_signal_shape() override;
 
       //! Initialization
-      virtual void initialize(const datatools::properties & config_,
-                              const mygsl::unary_function_dict_type & functors_);
+      void initialize(const datatools::properties & config_,
+                              const mygsl::unary_function_dict_type & functors_) override;
 
       //! Reset
-      virtual void reset();
+      void reset() override;
 
       //! Check initialization status
-      virtual bool is_initialized() const;
+      bool is_initialized() const override;
 
       //! Set the polarity of the signal
       void set_polarity(polarity_type);
@@ -125,10 +125,10 @@ namespace mctools {
       double get_amplitude() const;
 
       //! The minimum bound of the non-zero domain (default is minus infinity)
-      virtual double get_non_zero_domain_min() const;
+      double get_non_zero_domain_min() const override;
 
       //! The maximum bound of the non-zero domain (default is plus infinity)
-      virtual double get_non_zero_domain_max() const;
+      double get_non_zero_domain_max() const override;
 
       //! Return the width of the signal
       double get_duration() const;
@@ -146,10 +146,10 @@ namespace mctools {
       double get_q() const;
 
       //! Smart printing
-      virtual void tree_dump(std::ostream & out_ = std::clog,
+      void tree_dump(std::ostream & out_ = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_ = false) const;
+                             bool inherit_ = false) const override;
 
     protected:
 
@@ -160,7 +160,7 @@ namespace mctools {
       void _compute_parameters();
 
       //! Evaluation from parameters
-      double _eval(double x_) const;
+      double _eval(double x_) const override;
 
     private:
 

--- a/source/bxmctools/include/mctools/simulated_data.h
+++ b/source/bxmctools/include/mctools/simulated_data.h
@@ -272,16 +272,16 @@ namespace mctools {
     explicit simulated_data(int collection_type_);
 
     /// Destructor
-    virtual ~simulated_data();
+    ~simulated_data() override;
 
     /// Reset the internal data
-    virtual void clear();
+    void clear() override;
 
     /// \deprecated Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_          = false) const;
+                           bool inherit_          = false) const override;
     
     //! Smart print
     //! 

--- a/source/bxmctools/include/mctools/simulated_data_input_module.h
+++ b/source/bxmctools/include/mctools/simulated_data_input_module.h
@@ -38,18 +38,18 @@ namespace mctools {
     simulated_data_input_module(datatools::logger::priority logging_priority_ = datatools::logger::PRIO_FATAL);
 
     // Destructor :
-    virtual ~simulated_data_input_module();
+    ~simulated_data_input_module() override;
 
     /// Initialization
-    virtual void initialize(const datatools::properties & /* config_ */,
+    void initialize(const datatools::properties & /* config_ */,
                             datatools::service_manager & /* service_mgr_ */,
-                            dpp::module_handle_dict_type & /* modules_map_ */);
+                            dpp::module_handle_dict_type & /* modules_map_ */) override;
 
     /// Reset
-    virtual void reset();
+    void reset() override;
 
     /// Data record processing
-    virtual dpp::base_module::process_status process(datatools::things & /* data_ */);
+    dpp::base_module::process_status process(datatools::things & /* data_ */) override;
 
     bool is_terminated() const;
 

--- a/source/bxmctools/include/mctools/simulated_data_reader.h
+++ b/source/bxmctools/include/mctools/simulated_data_reader.h
@@ -82,7 +82,7 @@ namespace mctools {
     simulated_data_reader(datatools::logger::priority logging_ = datatools::logger::PRIO_FATAL);
 
     /// Destructor
-    virtual ~simulated_data_reader();
+    ~simulated_data_reader() override;
 
     /// Check if reader is initialized
     bool is_initialized() const;
@@ -141,10 +141,10 @@ namespace mctools {
     int get_record_counter() const;
 
     /// Smart print
-    virtual void tree_dump(std::ostream & out_         = std::clog,
+    void tree_dump(std::ostream & out_         = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_               = false) const;
+                           bool inherit_               = false) const override;
 
   protected:
 

--- a/source/bxmctools/include/mctools/step_hit_processor_factory.h
+++ b/source/bxmctools/include/mctools/step_hit_processor_factory.h
@@ -130,7 +130,7 @@ namespace mctools {
     step_hit_processor_factory (datatools::logger::priority logging_ = datatools::logger::PRIO_WARNING);
 
     /// Destructor
-    virtual ~step_hit_processor_factory ();
+    ~step_hit_processor_factory () override;
 
     // /// Returns the mutable dictionary of instantiated processors
     // processor_dict_type & grab_processors ();
@@ -166,10 +166,10 @@ namespace mctools {
     void dump (std::ostream & out_) const;
 
     /// Smart print
-    virtual void tree_dump (std::ostream & out_         = std::clog,
+    void tree_dump (std::ostream & out_         = std::clog,
                             const std::string & title_  = "",
                             const std::string & indent_ = "",
-                            bool inherit_               = false) const;
+                            bool inherit_               = false) const override;
 
     /// Load a configuration object
     void load(const datatools::multi_properties & mprop_);

--- a/source/bxmctools/src/signal/signal_data.cc
+++ b/source/bxmctools/src/signal/signal_data.cc
@@ -190,7 +190,7 @@ namespace mctools {
     void signal_data::build_list_of_categories(std::vector<std::string> & cats_) const
     {
       cats_.clear();
-      for (const auto cat_entry : _signals_dict_) {
+      for (const auto& cat_entry : _signals_dict_) {
         cats_.push_back(cat_entry.first);
       }
       return;
@@ -222,7 +222,7 @@ namespace mctools {
         out_ << indent_ << datatools::i_tree_dumpable::tag
              << "Signal categories : " << '[' << _signals_dict_.size() << ']' << std::endl;
         std::size_t cat_counter = 0;
-        for (const auto cat_entry : _signals_dict_) {
+        for (const auto& cat_entry : _signals_dict_) {
           out_ << indent_ << datatools::i_tree_dumpable::skip_tag;
           if (++cat_counter != _signals_dict_.size()) {
             out_ << datatools::i_tree_dumpable::tag;

--- a/source/bxmctools/src/signal/signal_shape_builder.cc
+++ b/source/bxmctools/src/signal/signal_shape_builder.cc
@@ -224,14 +224,14 @@ namespace mctools {
     void signal_shape_builder::_update_all_functors_()
     {
       _all_functors_.clear();
-      for (const auto rfpair : _reference_functors_) {
+      for (const auto& rfpair : _reference_functors_) {
         std::string key;
         std::ostringstream key_oss;
         key_oss << reference_functor_prefix() << rfpair.first;
         key = key_oss.str();
         _all_functors_[key] = rfpair.second;
       }
-      for (const auto fpair : _functors_) {
+      for (const auto& fpair : _functors_) {
         _all_functors_[fpair.first] = fpair.second;
       }
       return;

--- a/source/bxmctools/testing/snemo_signal_geiger_anode_signal_shape.h
+++ b/source/bxmctools/testing/snemo_signal_geiger_anode_signal_shape.h
@@ -102,8 +102,8 @@ namespace snemo {
       }
 
       //! Initialization
-      virtual void initialize(const datatools::properties & config_,
-                              const mygsl::unary_function_dict_type & functors_)
+      void initialize(const datatools::properties & config_,
+                      const mygsl::unary_function_dict_type & functors_) override
       {
         this->mygsl::i_unary_function::_base_initialize(config_, functors_);
 
@@ -196,7 +196,7 @@ namespace snemo {
       }
 
       //! Reset
-      virtual void reset()
+      void reset() override
       {
         _bottom_cathode_shape_.reset();
         _top_cathode_shape_.reset();
@@ -206,7 +206,7 @@ namespace snemo {
       }
 
       //! Check initialization status
-      virtual bool is_initialized() const
+      bool is_initialized() const override
       {
         if (!this->i_unary_function::is_initialized()) return false;
         if (!datatools::is_valid(_t0_)) return false;
@@ -238,7 +238,7 @@ namespace snemo {
       }
 
       //! Evaluation from parameters
-      double _eval(double time_) const
+      double _eval(double time_) const override
       {
         double sig = _bottom_cathode_shape_(time_) + _top_cathode_shape_(time_);
         return sig;

--- a/source/bxmygsl/include/mygsl/best_value.h
+++ b/source/bxmygsl/include/mygsl/best_value.h
@@ -57,7 +57,7 @@ namespace mygsl {
                   double error_high_,
                   double CL_);
 
-      virtual ~best_value ();
+      ~best_value () override;
 
     private:
 

--- a/source/bxmygsl/include/mygsl/composite_function.h
+++ b/source/bxmygsl/include/mygsl/composite_function.h
@@ -52,17 +52,17 @@ namespace mygsl {
                        const const_unary_function_handle_type & hcg_);
 
     //! Destructor
-    virtual ~composite_function();
+    ~composite_function() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the composite function
-    void reset();
+    void reset() override;
 
     //! Set the first functor
     void set_f(const i_unary_function &);
@@ -77,24 +77,24 @@ namespace mygsl {
     bool has_g() const;
 
     //! Check if the function has an explicit domain of definition (default: false)
-    /* virtual */ bool has_explicit_domain_of_definition() const;
+    /* virtual */ bool has_explicit_domain_of_definition() const override;
 
-    /* virtual */ bool is_in_domain_of_definition(double x_) const;
+    /* virtual */ bool is_in_domain_of_definition(double x_) const override;
 
-    /* virtual */ double get_non_zero_domain_min() const;
+    /* virtual */ double get_non_zero_domain_min() const override;
 
-    /* virtual */ double get_non_zero_domain_max() const;
+    /* virtual */ double get_non_zero_domain_max() const override;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected :
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/convolution_function.h
+++ b/source/bxmygsl/include/mygsl/convolution_function.h
@@ -60,17 +60,17 @@ namespace mygsl {
                          std::size_t size_ = 1000);
 
     //! Destructor
-    virtual ~convolution_function();
+    ~convolution_function() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the function
-    void reset();
+    void reset() override;
 
     //! Set the first functor
     void set_f(const i_unary_function &);
@@ -97,10 +97,10 @@ namespace mygsl {
     std::size_t get_limit() const;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     /// \brief Interface parameters for GSL function
     class convolution_term : public i_unary_function
@@ -111,10 +111,10 @@ namespace mygsl {
       convolution_term(const convolution_function & cf_, double t_);
 
       /// The minimum bound of the non-zero domain
-      /* virtual */ double get_non_zero_domain_min() const;
+      /* virtual */ double get_non_zero_domain_min() const override;
 
       /// The minimum bound of the non-zero domain
-      /* virtual */ double get_non_zero_domain_max() const;
+      /* virtual */ double get_non_zero_domain_max() const override;
 
       /// Smart print
       void print(std::ostream & = std::clog, const std::string & title_ = "") const;
@@ -122,7 +122,7 @@ namespace mygsl {
     protected:
 
       /// Function interface
-      virtual double _eval(double) const;
+      double _eval(double) const override;
 
     private:
 
@@ -139,7 +139,7 @@ namespace mygsl {
   protected:
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
     void _at_init();
 

--- a/source/bxmygsl/include/mygsl/datapoint.h
+++ b/source/bxmygsl/include/mygsl/datapoint.h
@@ -31,7 +31,7 @@ namespace mygsl {
               double sigma_y_ = std::numeric_limits<double>::quiet_NaN());
 
     /// Destructor
-    virtual ~datapoint();
+    ~datapoint() override;
 
     /// Return the X coordinate
     const double & x() const;

--- a/source/bxmygsl/include/mygsl/function_with_domain.h
+++ b/source/bxmygsl/include/mygsl/function_with_domain.h
@@ -62,28 +62,28 @@ namespace mygsl {
     function_with_domain(const i_unary_function & functor_, const interval & domain_);
 
     //! Destructor
-    virtual ~function_with_domain();
+    ~function_with_domain() override;
 
     //! Check the domain of definition
-    virtual bool has_explicit_domain_of_definition() const;
+    bool has_explicit_domain_of_definition() const override;
 
     //! Check is a value is in the domain of definition
-    virtual bool is_in_domain_of_definition(double x_) const;
+    bool is_in_domain_of_definition(double x_) const override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the functor
-    virtual void reset();
+    void reset() override;
 
   protected:
 
     //! Evaluation
-    virtual double _eval(double x_) const;
+    double _eval(double x_) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/functor_factory.h
+++ b/source/bxmygsl/include/mygsl/functor_factory.h
@@ -61,7 +61,7 @@ namespace mygsl {
     functor_factory(uint32_t flags_);
 
     //! Destructor
-    virtual ~functor_factory();
+    ~functor_factory() override;
 
     //! Create a functor without initialization
     void create(unary_function_handle_type & handle_,
@@ -79,10 +79,10 @@ namespace mygsl {
                 unary_function_dict_type & functors_);
 
     //! Smart dump
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 

--- a/source/bxmygsl/include/mygsl/gate_function.h
+++ b/source/bxmygsl/include/mygsl/gate_function.h
@@ -63,17 +63,17 @@ namespace mygsl {
                   double amplitude_ = std::numeric_limits<double>::quiet_NaN());
 
     //! Destructor
-    virtual ~gate_function();
+    ~gate_function() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the function
-    virtual void reset();
+    void reset() override;
 
     //! Set the width
     void set_width(double width_);
@@ -94,21 +94,21 @@ namespace mygsl {
     double get_amplitude() const;
 
     //! The minimum bound of the non-zero domain (default is plus infinity)
-    double get_non_zero_domain_min() const;
+    double get_non_zero_domain_min() const override;
 
     //! The maximum bound of the non-zero domain (default is plus infinity)
-    double get_non_zero_domain_max() const;
+    double get_non_zero_domain_max() const override;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected :
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
     //! Set default attributes values
     void _set_defaults();

--- a/source/bxmygsl/include/mygsl/gaussian_function.h
+++ b/source/bxmygsl/include/mygsl/gaussian_function.h
@@ -53,17 +53,17 @@ namespace mygsl {
                       double amplitude_);
 
     //! Destructor
-    virtual ~gaussian_function();
+    ~gaussian_function() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the function
-    void reset();
+    void reset() override;
 
     //! Set the sigma
     void set_sigma(double sigma_);
@@ -90,15 +90,15 @@ namespace mygsl {
     void reset_amplitude();
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
     //! Set default attributes values
     void _set_defaults();

--- a/source/bxmygsl/include/mygsl/gompertz_function.h
+++ b/source/bxmygsl/include/mygsl/gompertz_function.h
@@ -26,7 +26,7 @@ namespace mygsl {
                       double growth_rate_);
 
     //! Destructor
-    virtual ~gompertz_function();
+    ~gompertz_function() override;
 
     //! Set asymptote
     void set_asymptote(double asymptote_);
@@ -47,25 +47,25 @@ namespace mygsl {
     double get_growth_rate() const;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the function
-    virtual void reset();
+    void reset() override;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
     //! Set default attributes values
     void _set_defaults();

--- a/source/bxmygsl/include/mygsl/heaviside_function.h
+++ b/source/bxmygsl/include/mygsl/heaviside_function.h
@@ -28,7 +28,7 @@ namespace mygsl {
     heaviside_function(convention_type convention_ = CONVENTION_INVALID);
 
     //! Destructor
-    virtual ~heaviside_function();
+    ~heaviside_function() override;
 
     //! Set the convention
     void set_convention(convention_type convention_);
@@ -37,28 +37,28 @@ namespace mygsl {
     convention_type get_convention() const;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the function
-    void reset();
+    void reset() override;
 
     //! The minimum bound of the non-zero domain (default is plus infinity)
-    double get_non_zero_domain_min() const;
+    double get_non_zero_domain_min() const override;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
     //! Set default attributes values
     void _set_defaults();

--- a/source/bxmygsl/include/mygsl/histogram.h
+++ b/source/bxmygsl/include/mygsl/histogram.h
@@ -77,7 +77,7 @@ namespace mygsl {
 
     histogram (const std::vector<double> & ranges_);
 
-    virtual ~histogram ();
+    ~histogram () override;
 
     histogram (const histogram &);
 
@@ -230,10 +230,10 @@ namespace mygsl {
                                 double);
 
     /// Main interface method for smart dump
-    virtual void tree_dump (std::ostream& out = std::clog,
+    void tree_dump (std::ostream& out = std::clog,
                             const std::string& title  = "",
                             const std::string& indent = "",
-                            bool inherit = false) const;
+                            bool inherit = false) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/histogram_2d.h
+++ b/source/bxmygsl/include/mygsl/histogram_2d.h
@@ -125,7 +125,7 @@ namespace mygsl {
     histogram_2d (const std::vector<double> & xranges_,
                   const std::vector<double> & yranges_);
 
-    virtual ~histogram_2d ();
+    ~histogram_2d () override;
 
     histogram_2d (const histogram_2d &);
 

--- a/source/bxmygsl/include/mygsl/histogram_pool.h
+++ b/source/bxmygsl/include/mygsl/histogram_pool.h
@@ -59,12 +59,12 @@ namespace mygsl {
       /// Constructor
       histogram_entry_type();
       /// Destructor
-      virtual ~histogram_entry_type();
+      ~histogram_entry_type() override;
       /// Smart print
-      virtual void tree_dump(std::ostream      & out_    = std::clog,
+      void tree_dump(std::ostream      & out_    = std::clog,
                              const std::string & title_  = "",
                              const std::string & indent_ = "",
-                             bool inherit_               = false) const;
+                             bool inherit_               = false) const override;
 
 
       DATATOOLS_SERIALIZATION_DECLARATION_NOINHERIT()
@@ -92,7 +92,7 @@ namespace mygsl {
     histogram_pool(const std::string & desc_);
 
     /// Destructor
-    virtual ~histogram_pool();
+    ~histogram_pool() override;
 
     /// Static method to initialize 1D histogram
     static void init_histo_1d(histogram_1d & h1_,
@@ -184,10 +184,10 @@ namespace mygsl {
                           const std::string & group_ = "");
 
     /// Smart print
-    virtual void tree_dump(std::ostream      & out    = std::clog,
+    void tree_dump(std::ostream      & out    = std::clog,
                            const std::string & title  = "",
                            const std::string & indent = "",
-                           bool inherit               = false) const;
+                           bool inherit               = false) const override;
 
     /// Set logging priority
     void set_logging_priority(datatools::logger::priority);

--- a/source/bxmygsl/include/mygsl/histogram_pool.h
+++ b/source/bxmygsl/include/mygsl/histogram_pool.h
@@ -67,7 +67,7 @@ namespace mygsl {
                              bool inherit_               = false) const;
 
 
-      DATATOOLS_SERIALIZATION_DECLARATION()
+      DATATOOLS_SERIALIZATION_DECLARATION_NOINHERIT()
     };
 
     /// Alias to histogram dictionnary

--- a/source/bxmygsl/include/mygsl/i_unary_function.h
+++ b/source/bxmygsl/include/mygsl/i_unary_function.h
@@ -69,7 +69,7 @@ namespace mygsl {
     i_unary_function(double epsilon_ = 0.0);
 
     //! Destructor
-    virtual ~i_unary_function();
+    ~i_unary_function() override;
 
     //! Check if the function has an explicit domain of definition (default: false)
     virtual bool has_explicit_domain_of_definition() const;
@@ -171,10 +171,10 @@ namespace mygsl {
     virtual bool is_initialized() const;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 

--- a/source/bxmygsl/include/mygsl/i_unary_function_with_derivative.h
+++ b/source/bxmygsl/include/mygsl/i_unary_function_with_derivative.h
@@ -34,7 +34,7 @@ namespace mygsl {
     i_unary_function_with_derivative(double epsilon_ = 0.0);
 
     //! Destructor
-    virtual ~i_unary_function_with_derivative();
+    ~i_unary_function_with_derivative() override;
 
     virtual double eval_f(double x_) const;
 
@@ -65,24 +65,24 @@ namespace mygsl {
     //! Constructor
     unary_function_promoted_with_numeric_derivative(const i_unary_function & functor_);
 
-    virtual bool is_in_domain_of_definition(double x_) const;
+    bool is_in_domain_of_definition(double x_) const override;
 
-    virtual bool has_explicit_domain_of_definition() const;
+    bool has_explicit_domain_of_definition() const override;
 
-    virtual double get_non_zero_domain_min() const;
+    double get_non_zero_domain_min() const override;
 
-    virtual double get_non_zero_domain_max() const;
+    double get_non_zero_domain_max() const override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Reset the functor
-    virtual void reset();
+    void reset() override;
 
   protected:
 
     //! Evaluation
-    virtual double _eval(double x_) const;
+    double _eval(double x_) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/i_unary_function_with_parameters.h
+++ b/source/bxmygsl/include/mygsl/i_unary_function_with_parameters.h
@@ -48,17 +48,17 @@ namespace mygsl {
     i_unary_function_with_parameters(const parameter_store & store_);
 
     //! Destructor
-    virtual ~i_unary_function_with_parameters();
+    ~i_unary_function_with_parameters() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the functor
-    virtual void reset();
+    void reset() override;
 
     //! Check if an external parameter store is set
     bool has_parameter_store() const;
@@ -92,18 +92,18 @@ namespace mygsl {
     void fetch_parameter(int param_index_, std::string & value_) const;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     //! Update parameter
-    void update_parameters();
+    void update_parameters() override;
 
   protected:
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
     //! Evaluation from parameters of the store
     virtual double _eval_from_parameters(double x_) const = 0;

--- a/source/bxmygsl/include/mygsl/identity_function.h
+++ b/source/bxmygsl/include/mygsl/identity_function.h
@@ -18,12 +18,12 @@ namespace mygsl {
     identity_function();
 
     //! Destructor
-    virtual ~identity_function();
+    ~identity_function() override;
 
   protected:
 
     //! Evaluation method
-    virtual double _eval(double x_) const;
+    double _eval(double x_) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/identity_function.h
+++ b/source/bxmygsl/include/mygsl/identity_function.h
@@ -30,9 +30,6 @@ namespace mygsl {
     //! Registration of the functor class
     MYGSL_UNARY_FUNCTOR_REGISTRATION_INTERFACE(identity_function)
 
-    //! Cloneable interface
-    DATATOOLS_CLONEABLE_DECLARATION(identity_function)
-
   };
 
 } // namespace mygsl

--- a/source/bxmygsl/include/mygsl/interval.h
+++ b/source/bxmygsl/include/mygsl/interval.h
@@ -74,7 +74,7 @@ namespace mygsl {
                 double eps_ = AUTO_EPS);
 
       /// Destructor
-      virtual ~interval ();
+      ~interval () override;
 
       void remove_min ();
 

--- a/source/bxmygsl/include/mygsl/kernel_smoother.h
+++ b/source/bxmygsl/include/mygsl/kernel_smoother.h
@@ -26,7 +26,7 @@ namespace mygsl {
     /// Constructor
     gauss_kernel_smoother(const double b_);
 
-    virtual ~gauss_kernel_smoother();
+    ~gauss_kernel_smoother() override;
 
     double eval(double xs_, double x_) const override;
 
@@ -51,12 +51,12 @@ namespace mygsl {
                                  const double b_);
 
     /// Destructor
-    virtual ~nw_sampled_function_smoother();
+    ~nw_sampled_function_smoother() override;
     
   protected:
 
     /// Evaluation of the smoothed function
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
  
   private:
 

--- a/source/bxmygsl/include/mygsl/linear_combination_function.h
+++ b/source/bxmygsl/include/mygsl/linear_combination_function.h
@@ -48,17 +48,17 @@ namespace mygsl {
                                 const const_unary_function_handle_type & f2_);
 
     //! Destructor
-    virtual ~linear_combination_function();
+    ~linear_combination_function() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the composite function
-    void reset();
+    void reset() override;
 
     //! Add a weighted term
     std::size_t add(double weight_, const i_unary_function &);
@@ -70,27 +70,27 @@ namespace mygsl {
     void change_weight(int term_index_, double weight_);
 
     //! Check if the function has an explicit domain of definition (default: false)
-    virtual bool has_explicit_domain_of_definition() const;
+    bool has_explicit_domain_of_definition() const override;
 
     //! Check if a value is in the explicit domain of definition (default: true)
-    virtual bool is_in_domain_of_definition(double x_) const;
+    bool is_in_domain_of_definition(double x_) const override;
 
     //! The minimum bound of the non-zero domain (default is minus infinity)
-    virtual double get_non_zero_domain_min() const;
+    double get_non_zero_domain_min() const override;
 
     //! The maximum bound of the non-zero domain (default is plus infinity)
-    virtual double get_non_zero_domain_max() const;
+    double get_non_zero_domain_max() const override;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected :
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
     //! Set default attributes values
     void _set_defaults();

--- a/source/bxmygsl/include/mygsl/linear_regression.h
+++ b/source/bxmygsl/include/mygsl/linear_regression.h
@@ -34,7 +34,7 @@ namespace mygsl {
       fit_data();
 
       /// Destructor
-      virtual ~fit_data();
+      ~fit_data() override;
 
       /// Check if the fit data are valid
       bool is_valid() const;
@@ -107,7 +107,7 @@ namespace mygsl {
     protected:
 
       /// Evaluate the Y value for a given X
-      virtual double _eval(double x_) const;
+      double _eval(double x_) const override;
 
     private:
 

--- a/source/bxmygsl/include/mygsl/linear_sampling.h
+++ b/source/bxmygsl/include/mygsl/linear_sampling.h
@@ -36,19 +36,19 @@ namespace mygsl {
     linear_sampling();
 
     /// Destructor
-    virtual ~linear_sampling();
+    ~linear_sampling() override;
 
     /// Return the minimum sample
-    virtual double get_min() const;
+    double get_min() const override;
 
     /// Return the maximum sample
-    virtual double get_max() const;
+    double get_max() const override;
 
     /// Return the number of steps
-    std::size_t get_nsteps() const;
+    std::size_t get_nsteps() const override;
 
     /// Return the number of nsamples
-    std::size_t get_nsamples() const;
+    std::size_t get_nsamples() const override;
 
     /// Return the step
     double get_step() const;
@@ -57,22 +57,22 @@ namespace mygsl {
     double get_guard() const;
 
     /// Check the initialization status of the sampling
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Reset/invalidate the sampling
-    virtual void initialize(const datatools::properties &);
+    void initialize(const datatools::properties &) override;
 
     /// Reset/invalidate the sampling
-    virtual void reset();
+    void reset() override;
 
     /// Return the index and a classification associated to a value
-    virtual bool value_to_index(const double x_,
+    bool value_to_index(const double x_,
                                 std::size_t & index_,
-                                sampling::index_classification_type & classification_flags_) const;
+                                sampling::index_classification_type & classification_flags_) const override;
 
     /// Return the value associated to a given index
-    virtual sampling::index_classification_type
-    index_to_value(const std::size_t index_, double & value_) const;
+    sampling::index_classification_type
+    index_to_value(const std::size_t index_, double & value_) const override;
 
     /// Build sampling from min to max and given number of steps
     ///

--- a/source/bxmygsl/include/mygsl/logistic_function.h
+++ b/source/bxmygsl/include/mygsl/logistic_function.h
@@ -24,7 +24,7 @@ namespace mygsl {
     logistic_function(double steepness_, double midpoint_, double amplitude_);
 
     //! Destructor
-    virtual ~logistic_function();
+    ~logistic_function() override;
 
     //! Set the steepness
     void set_steepness(double steepness_);
@@ -45,25 +45,25 @@ namespace mygsl {
     double get_amplitude() const;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the function
-    virtual void reset();
+    void reset() override;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
     //! Set default attributes values
     void _set_defaults();

--- a/source/bxmygsl/include/mygsl/min_max.h
+++ b/source/bxmygsl/include/mygsl/min_max.h
@@ -62,10 +62,10 @@ namespace mygsl {
     void add(double value_);
 
     /// Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/multi_eval.h
+++ b/source/bxmygsl/include/mygsl/multi_eval.h
@@ -103,11 +103,11 @@ namespace mygsl {
                            int i_,
                            const double * params_);
 
-    virtual ~unary_eval_from_multi ();
+    ~unary_eval_from_multi () override;
 
   protected:
 
-   double _eval(double x_) const;
+   double _eval(double x_) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/multidimensional_minimization.h
+++ b/source/bxmygsl/include/mygsl/multidimensional_minimization.h
@@ -53,7 +53,7 @@ namespace mygsl {
     multidimensional_minimization_system (double slope_ = DEFAULT_OUT_OF_LIMIT_SLOPE,
                                           bool use_numeric_eval_ = false);
 
-    virtual ~multidimensional_minimization_system ();
+    ~multidimensional_minimization_system () override;
 
     struct func_eval_f_param
       : public mygsl::i_unary_function
@@ -64,7 +64,7 @@ namespace mygsl {
                         multidimensional_minimization_system & sys_);
     protected:
       
-      virtual double _eval(double x_) const;
+      double _eval(double x_) const override;
 
     public:
       
@@ -151,11 +151,11 @@ namespace mygsl {
     struct default_step_action
       : public at_step_action
     {
-      virtual void action (int status_ ,
+      void action (int status_ ,
                            size_t iter_ ,
                            double * x_ ,
                            size_t   dim_ ,
-                           double f_);
+                           double f_) override;
     };
 
     static default_step_action __default_step_action;

--- a/source/bxmygsl/include/mygsl/multimin.h
+++ b/source/bxmygsl/include/mygsl/multimin.h
@@ -313,11 +313,11 @@ namespace mygsl {
 
     struct default_step_action : public at_step_action
     {
-      virtual void action (int status_ ,
+      void action (int status_ ,
                            size_t iter_ ,
                            double * x_ ,
                            size_t   dim_ ,
-                           double f_);
+                           double f_) override;
     };
 
     static default_step_action _default_step_action_;

--- a/source/bxmygsl/include/mygsl/multiparameter_system.h
+++ b/source/bxmygsl/include/mygsl/multiparameter_system.h
@@ -120,7 +120,7 @@ namespace mygsl {
 
   struct multiparameter_system_test : public multiparameter_system
   {
-    virtual void compute_automatic_params ()
+    void compute_automatic_params () override
     {
       for (size_t i = 0; i < get_number_of_auto_params (); i++)
 	{

--- a/source/bxmygsl/include/mygsl/ode.h
+++ b/source/bxmygsl/include/mygsl/ode.h
@@ -78,7 +78,7 @@ namespace mygsl {
 
     struct default_step_action : public at_step_action
     {
-      virtual void action ( double t_ , double * y_ , size_t dim_ );
+      void action ( double t_ , double * y_ , size_t dim_ ) override;
     };
 
     static default_step_action _default_step_action_;

--- a/source/bxmygsl/include/mygsl/one_dimensional_minimization.h
+++ b/source/bxmygsl/include/mygsl/one_dimensional_minimization.h
@@ -50,11 +50,11 @@ namespace mygsl {
 
     struct default_step_action : public at_step_action
     {
-      virtual void action (int status_,
+      void action (int status_,
                            size_t iter_,
                            double a_,
                            double b_,
-                           double c_);
+                           double c_) override;
     };
 
   public:

--- a/source/bxmygsl/include/mygsl/one_dimensional_root_finding.h
+++ b/source/bxmygsl/include/mygsl/one_dimensional_root_finding.h
@@ -57,11 +57,11 @@ namespace mygsl {
 
     struct default_step_action : public at_step_action
     {
-      virtual void action (int status_,
+      void action (int status_,
                            size_t iter_,
                            double a_,
                            double b_,
-                           double c_);
+                           double c_) override;
     };
 
     void unset_step_action ();

--- a/source/bxmygsl/include/mygsl/parameter_store.h
+++ b/source/bxmygsl/include/mygsl/parameter_store.h
@@ -149,7 +149,7 @@ namespace mygsl {
     parameter_store();
 
     //! Destructor
-    virtual ~parameter_store();
+    ~parameter_store() override;
 
     //! Reset the store
     void reset();
@@ -187,10 +187,10 @@ namespace mygsl {
     void update();
 
     //! Main interface method for smart dump
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
     //! Check is a subscriber object is currently a subscriber of the store
     bool is_registered_subscriber(const i_subscriber & s_) const;

--- a/source/bxmygsl/include/mygsl/plain_function_wrapper.h
+++ b/source/bxmygsl/include/mygsl/plain_function_wrapper.h
@@ -56,22 +56,22 @@ namespace mygsl {
     plain_function_wrapper(const plain_function_type &);
 
     //! Destructor
-    virtual ~plain_function_wrapper();
+    ~plain_function_wrapper() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the functor
-    virtual void reset();
+    void reset() override;
 
   protected:
 
     //! Evaluation method
-    virtual double _eval(double x_) const;
+    double _eval(double x_) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/polynomial.h
+++ b/source/bxmygsl/include/mygsl/polynomial.h
@@ -49,7 +49,7 @@ namespace mygsl {
     polynomial(const polynomial& p_);
 
     //! Destructor
-    virtual ~polynomial();
+    ~polynomial() override;
 
     void set_coefficients(const std::vector<double>& c_);
 
@@ -68,14 +68,14 @@ namespace mygsl {
                bool eol_ = false) const;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the polynomial
-    void reset();
+    void reset() override;
 
     /*
      * L(x) = p0 + p1 * x^1
@@ -134,14 +134,14 @@ namespace mygsl {
                        double y1_, double y2_, double y3_);
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected :
 
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
   public:
 

--- a/source/bxmygsl/include/mygsl/product_function.h
+++ b/source/bxmygsl/include/mygsl/product_function.h
@@ -46,17 +46,17 @@ namespace mygsl {
     product_function(const i_unary_function & f_, const i_unary_function & g_);
 
     //! Destructor
-    virtual ~product_function();
+    ~product_function() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the composite function
-    void reset();
+    void reset() override;
 
     //! Set the first functor
     void set_f(const i_unary_function &);
@@ -71,24 +71,24 @@ namespace mygsl {
     bool has_g() const;
 
     //! Check if the function has an explicit domain of definition (default: false)
-    /* virtual */ bool has_explicit_domain_of_definition() const;
+    /* virtual */ bool has_explicit_domain_of_definition() const override;
 
-    /* virtual */ bool is_in_domain_of_definition(double x_) const;
+    /* virtual */ bool is_in_domain_of_definition(double x_) const override;
 
-    /* virtual */ double get_non_zero_domain_min() const;
+    /* virtual */ double get_non_zero_domain_min() const override;
 
-    /* virtual */ double get_non_zero_domain_max() const;
+    /* virtual */ double get_non_zero_domain_max() const override;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected :
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/rectangular_function.h
+++ b/source/bxmygsl/include/mygsl/rectangular_function.h
@@ -41,7 +41,7 @@ namespace mygsl {
     rectangular_function(convention_type convention_ = CONVENTION_INVALID);
 
     //! Destructor
-    virtual ~rectangular_function();
+    ~rectangular_function() override;
 
     //! Set the convention
     void set_convention(convention_type convention_);
@@ -50,31 +50,31 @@ namespace mygsl {
     convention_type get_convention() const;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the function
-    virtual void reset();
+    void reset() override;
 
     //! The minimum bound of the non-zero domain (default is plus infinity)
-    double get_non_zero_domain_min() const;
+    double get_non_zero_domain_min() const override;
 
     //! The maximum bound of the non-zero domain (default is plus infinity)
-    double get_non_zero_domain_max() const;
+    double get_non_zero_domain_max() const override;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
     //! Set default attributes values
     void _set_defaults();

--- a/source/bxmygsl/include/mygsl/tabulated_function.h
+++ b/source/bxmygsl/include/mygsl/tabulated_function.h
@@ -50,10 +50,10 @@ namespace mygsl {
   public:
 
     /// Check if the function has an explicit domain of definition (default: false)
-    virtual bool has_explicit_domain_of_definition() const;
+    bool has_explicit_domain_of_definition() const override;
 
     /// Check if a value is in the domain of definition of the function (default: true)
-    virtual bool is_in_domain_of_definition(double x_) const;
+    bool is_in_domain_of_definition(double x_) const override;
 
     /// Default constructor
     tabulated_function(const std::string & interp_name_ = "");
@@ -62,7 +62,7 @@ namespace mygsl {
     tabulated_function(const tabulated_function & tab_func_);
 
     /// Destructor
-    virtual ~tabulated_function();
+    ~tabulated_function() override;
 
     /// Assignement
     tabulated_function & operator=(const tabulated_function& tab_func_);
@@ -135,25 +135,25 @@ namespace mygsl {
 
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the functor
-    void reset();
+    void reset() override;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 
     //! Evaluation
-    virtual double _eval(double x_) const;
+    double _eval(double x_) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/tabulated_sampling.h
+++ b/source/bxmygsl/include/mygsl/tabulated_sampling.h
@@ -39,19 +39,19 @@ namespace mygsl {
     tabulated_sampling();
 
     /// Destructor
-    virtual ~tabulated_sampling();
+    ~tabulated_sampling() override;
 
     /// Return the minimum sample
-    virtual double get_min() const;
+    double get_min() const override;
 
     /// Return the maximum sample
-    virtual double get_max() const;
+    double get_max() const override;
 
     /// Return the number of steps
-    std::size_t get_nsteps() const;
+    std::size_t get_nsteps() const override;
 
     /// Return the number of nsamples
-    std::size_t get_nsamples() const;
+    std::size_t get_nsamples() const override;
 
     /// Return the absolute guard distance around sampling alues
     double get_guard() const;
@@ -63,23 +63,23 @@ namespace mygsl {
     double get_max_step() const;
 
     /// Check the initialization status of the sampling
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     /// Reset/invalidate the sampling
-    virtual void initialize(const datatools::properties &);
+    void initialize(const datatools::properties &) override;
 
     /// Reset/invalidate the sampling
-    virtual void reset();
+    void reset() override;
 
     /// Return the index and a classification associated to a value
-    virtual bool value_to_index(const double x_,
+    bool value_to_index(const double x_,
                                 std::size_t & index_,
-                                sampling::index_classification_type & classification_flags_) const;
+                                sampling::index_classification_type & classification_flags_) const override;
 
     /// Return the value associated to a given index
-    virtual sampling::index_classification_type
+    sampling::index_classification_type
     index_to_value(const std::size_t index_,
-                   double & value_) const;
+                   double & value_) const override;
 
     /// Set the absolute guard distance around sampling alues
     void set_guard(const double guard_);

--- a/source/bxmygsl/include/mygsl/triangle_function.h
+++ b/source/bxmygsl/include/mygsl/triangle_function.h
@@ -69,17 +69,17 @@ namespace mygsl {
                       double amplitude_);
 
     //! Destructor
-    virtual ~triangle_function();
+    ~triangle_function() override;
 
     //! Check initialization status
-    virtual bool is_initialized() const;
+    bool is_initialized() const override;
 
     //! Initialization from a container of parameters and a dictionary of functors
-    virtual void initialize(const datatools::properties & config_,
-                            const unary_function_dict_type & functors_);
+    void initialize(const datatools::properties & config_,
+                            const unary_function_dict_type & functors_) override;
 
     //! Reset the function
-    void reset();
+    void reset() override;
 
     //! Set the head width
     void set_head_width(double head_width_);
@@ -106,21 +106,21 @@ namespace mygsl {
     double get_amplitude() const;
 
     //! The minimum bound of the non-zero domain (default is plus infinity)
-    double get_non_zero_domain_min() const;
+    double get_non_zero_domain_min() const override;
 
     //! The maximum bound of the non-zero domain (default is plus infinity)
-    double get_non_zero_domain_max() const;
+    double get_non_zero_domain_max() const override;
 
     //! Smart printing
-    virtual void tree_dump(std::ostream & out_ = std::clog,
+    void tree_dump(std::ostream & out_ = std::clog,
                            const std::string & title_  = "",
                            const std::string & indent_ = "",
-                           bool inherit_ = false) const;
+                           bool inherit_ = false) const override;
 
   protected:
 
     //! Evaluation
-    double _eval(double x_) const;
+    double _eval(double x_) const override;
 
     //! Set default attributes values
     void _set_defaults();

--- a/source/bxmygsl/include/mygsl/zero_function.h
+++ b/source/bxmygsl/include/mygsl/zero_function.h
@@ -18,12 +18,12 @@ namespace mygsl {
     zero_function();
 
     //! Destructor
-    virtual ~zero_function();
+    ~zero_function() override;
 
   protected:
 
     //! Evaluation method
-    virtual double _eval(double x_) const;
+    double _eval(double x_) const override;
 
   private:
 

--- a/source/bxmygsl/include/mygsl/zero_function.h
+++ b/source/bxmygsl/include/mygsl/zero_function.h
@@ -29,10 +29,6 @@ namespace mygsl {
 
     //! Registration of the functor class
     MYGSL_UNARY_FUNCTOR_REGISTRATION_INTERFACE(zero_function)
-
-    //! Cloneable interface
-    DATATOOLS_CLONEABLE_DECLARATION(zero_function)
-
   };
 
 } // namespace mygsl

--- a/source/bxmygsl/src/identity_function.cc
+++ b/source/bxmygsl/src/identity_function.cc
@@ -8,8 +8,6 @@ namespace mygsl {
   MYGSL_UNARY_FUNCTOR_REGISTRATION_IMPLEMENT(identity_function,
                                              "mygsl::identity_function")
 
-  DATATOOLS_CLONEABLE_IMPLEMENTATION(identity_function)
-
   identity_function::identity_function()
   {
     return;

--- a/source/bxmygsl/src/zero_function.cc
+++ b/source/bxmygsl/src/zero_function.cc
@@ -8,8 +8,6 @@ namespace mygsl {
   MYGSL_UNARY_FUNCTOR_REGISTRATION_IMPLEMENT(zero_function,
                                              "mygsl::zero_function")
 
-  DATATOOLS_CLONEABLE_IMPLEMENTATION(zero_function)
-
   zero_function::zero_function()
   {
     return;


### PR DESCRIPTION
In building Bayeux for SuperNEMO with the latest Clang compiler, a huge number of warnings are emitted through it implementing a stricter set of checks than GCC (at least up to GCC7). These are mostly straightforward and related to missing `override`s on overriden virtual functions, unused variables, and avoiding copies in range-based for loops. The remaining warnings will be noted in Issues here and bxdecay0, and cross-referenced. 

For reference, `clang-tidy` implements the use of `override` per the CPP Core Guidelines, and discussion at these links:

- http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-override
- https://github.com/isocpp/CppCoreGuidelines/pull/1448
- https://github.com/isocpp/CppCoreGuidelines/issues/1446
- https://github.com/isocpp/CppCoreGuidelines/issues/721#issuecomment-598878968 

The move from `virtual fun();` to `fun() override;` may look odd at first, but the first link makes the rationale clear.