### PR TITLE
Fix bugs in time_slicer_generator and primary_generator

### DIFF
--- a/source/bxgenbb_help/src/time_slicer_generator.cc
+++ b/source/bxgenbb_help/src/time_slicer_generator.cc
@@ -227,7 +227,7 @@ namespace genbb {
     if (!has_mode()) {
       if (config_.has_key("mode")) {
         std::string mode = config_.fetch_string("mode");
-        if (mode == "prompt_only") {
+        if (mode == "prompt_event_only") {
           set_mode(SM_PROMPT_EVENT_ONLY);
         } else if (mode == "delayed_event_only") {
           set_mode(SM_DELAYED_EVENT_ONLY);

--- a/source/bxmctools/src/g4/primary_generator.cc
+++ b/source/bxmctools/src/g4/primary_generator.cc
@@ -353,13 +353,6 @@ namespace mctools {
         mgr.grab_CT_map()["VG"].stop();
       }
 
-      // Save current event vertex:
-      _event_action_->grab_event_data().set_vertex(_current_vertex_);
-      if (datatools::is_valid(_current_time_)) {
-        // Save current event time:
-        _event_action_->grab_event_data().set_time(_current_time_);
-      }
-
       return;
     }
 
@@ -377,7 +370,7 @@ namespace mctools {
       ::genbb::primary_event & current_generated_event
           = _event_action_->grab_event_data().grab_primary_event();
 
-      manager & mgr = _event_action_->grab_run_action ().grab_manager();
+      manager & mgr = _event_action_->grab_run_action().grab_manager();
       if (mgr.using_time_stat()) {
         mgr.grab_CT_map()["EG"].start();
       }
@@ -410,6 +403,15 @@ namespace mctools {
 	if (_vertex_generator_ != nullptr) {
           _generate_vertex();
         }
+      }
+
+      if (geomtools::is_valid(_current_vertex_)) {
+	// Save current event vertex:
+	_event_action_->grab_event_data().set_vertex(_current_vertex_);
+      }
+      if (datatools::is_valid(_current_time_)) {
+        // Save current event time:
+        _event_action_->grab_event_data().set_time(_current_time_);
       }
 
       // Default event reference time:


### PR DESCRIPTION
- Fix configuration parameter name in class` genbb::time_slicer_generator`
- Fix missing vertex update in class `mctools::g4::primary_generator` when reusing vertex generated while processing the previous event 